### PR TITLE
Allow manifest "sources" to be any valid file name.

### DIFF
--- a/base/manifest-schema.json
+++ b/base/manifest-schema.json
@@ -45,7 +45,7 @@
 				"sources": {
 					"type": "object",
 					"patternProperties": {
-						"^\\w+$": {
+						"^[^\/\\0]+$": {
 							"type": "array",
 							"items": {
 								"type": "string",


### PR DESCRIPTION
My manifest was as follows:

```
    "packages": {
                "sources": {
                        "wheezy-backports/": [
                                "deb http://ftp.debian.org/debian/ wheezy-backports main",
                                "deb-src http://ftp.debian.org/debian/ wheezy-backports main"
                        ],
...
```

This was failing on the '-' character in 'wheezy-backports', which (from the documentation) is supposed to become `/etc/apt/sources.list.d/wheezy-backports.list`. These filenames should not have any more limitations on them than those in "path" (aside from not allowing a forward-slash character).

As an aside, it's also not obvious from the docs that the `.list` extension will be appended to the name. Looking at [other examples](https://github.com/andsens/bootstrap-vz/issues/1), it appears that this is the case, but it's certainly not obvious and should ideally be documented. The sources.list man page states that the `.list` extension is mandatory, but the bootstrap-vz docs currently only say:

> The key becomes the filename in /etc/apt/sources.list.d/
