### PR TITLE
Specify the exact requirements in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Other depencies include:
 * euca2ools
 * xfsprogs (If you want to use XFS as a filesystem)
 Also the following python libraries are required:
-* **boto**
+* **boto** ([version 2.14.0 or higher](https://github.com/boto/boto))
 * **jsonschema** ([version 2.0.0](https://pypi.python.org/pypi/jsonschema), only available through pip)
 * **termcolor**
 * **fysom**


### PR DESCRIPTION
It needs to be clear that we need a newer version of boto than is included in Wheezy's python-boto package.

Otherwise:

```
Registering the image as an AMI
register_image() got an unexpected keyword argument 'virtualization_type'
Traceback (most recent call last):
  File "~/bootstrap-vz/base/main.py", line 38, in run
    tasklist.run(info=bootstrap_info, dry_run=args.dry_run)
  File "~/bootstrap-vz/base/tasklist.py", line 29, in run
    task.run(info)
  File "~/bootstrap-vz/providers/ec2/tasks/ami.py", line 170, in run
    info.image = info.connection.register_image(**registration_params)
TypeError: register_image() got an unexpected keyword argument 'virtualization_type'
Rolling back
Removing the bundle files
Deleting the volume
Deleting workspace
Successfully completed rollback
root@domU-AA-BB-CC-DD-EE-FF:~/bootstrap-vz# apt-cache policy python-boto
python-boto:
  Installed: 2.3.0-1
  Candidate: 2.3.0-1
  Version table:
 *** 2.3.0-1 0
        500 http://http.debian.net/debian/ wheezy/main amd64 Packages
        100 /var/lib/dpkg/status
```

Required boto commit:
https://github.com/boto/boto/commit/e14f71da995672de43599ba0e10f8e7ed2d4d471
