### PR TITLE
zerofree is used against partitions, not devices

### DIFF
--- a/plugins/minimize_size/tasks.py
+++ b/plugins/minimize_size/tasks.py
@@ -62,15 +62,15 @@ class AddRequiredCommands(Task):
 
 
 class Zerofree(Task):
-	description = 'Zeroing unused blocks on the volume'
+	description = 'Zeroing unused blocks on the root partition'
 	phase = phases.volume_unmounting
-	predecessors = [filesystem.UnmountRoot, partitioning.UnmapPartitions]
-	successors = [volume.Detach]
+	predecessors = [filesystem.UnmountRoot]
+	successors = [partitioning.UnmapPartitions, volume.Detach]
 
 	@classmethod
 	def run(cls, info):
 		from common.tools import log_check_call
-		log_check_call(['zerofree', info.volume.device_path])
+		log_check_call(['zerofree', info.volume.partition_map.root.device_path])
 
 
 class ShrinkVolume(Task):


### PR DESCRIPTION
Anders,

I was trying to use the `minimize_size` plugin and got that error:

```
Zeroing unused blocks on the volume
zerofree: failed to open filesystem /dev/nbd0
Command 'zerofree /dev/nbd0' returned non-zero exit status 1
Traceback (most recent call last):
  File "/vagrant/base/main.py", line 66, in run
    tasklist.run(info=bootstrap_info, dry_run=args.dry_run)
  File "/vagrant/base/tasklist.py", line 59, in run
    task.run(info)
  File "/vagrant/plugins/minimize_size/tasks.py", line 73, in run
    log_check_call(['zerofree', info.volume.device_path])
  File "/vagrant/common/tools.py", line 7, in log_check_call
    raise CalledProcessError(status, ' '.join(command), '\n'.join(stderr))
CalledProcessError: Command 'zerofree /dev/nbd0' returned non-zero exit status 1
```

The problem is that `zerofree` should run on ext[234] filesystems, umounted or read-only, not on whole devices. So I made the necessary modifications to execute it against the root partition. These are the results I've got witch this patch (don't mind the machine name, it's an old vagrant machine, but with the last version of wheezy - not the RC1):

```
[root@debian-70rc1-x64-vbox4210:/target]# ls -lh
total 1.1G
-rw-r--r-- 1 root root 400M Mar 24 09:40 debian-wheezy-amd64-140324.box
-rw-r--r-- 1 root root 378M Mar 24 09:52 debian-wheezy-amd64-140324-shrink.box
-rw-r--r-- 1 root root 193M Mar 24 09:26 debian-wheezy-amd64-140324-zerofree+shrink.box
```

Regards,
Tiago.
