### PR TITLE
Stop VBoxService after guest additions installation

### DIFF
--- a/providers/virtualbox/tasks/guest_additions.py
+++ b/providers/virtualbox/tasks/guest_additions.py
@@ -60,6 +60,6 @@ class InstallGuestAdditions(Task):
 			       'it should exit with status 1').format(status=status)
 			raise TaskError(msg)
 
-		log_call(['/usr/sbin/chroot', info.root, '/usr/sbin/service', 'vboxadd-service', 'stop'])
+		log_call(['chroot', info.root, 'service', 'vboxadd-service', 'stop'])
 		root.remove_mount(mount_path)
 		os.rmdir(mount_path)


### PR DESCRIPTION
I've been talking with Anders about this issue over the past few days. The problem is that sometimes the vagrant manifest could not be built as VBoxService continues to run after the VirtualBox Guest Additions installation, preventing the chroot's `/dev` from being unmounted and crashing the entire build process. This patch just calls its `init.d` to stop it.

It really shouldn't break anything, as if you call it when the service is not running, it would just show this information on it's output and return 0 anyway.
