### PR TITLE
Update documentation about zerofree settings

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -107,7 +107,9 @@ and contribute to this list!
 	<h3>Settings</h3>
 	<ul>
 		<li>
-			<tt>zerofree</tt>: Path to the zerofree executable. If specified, the tool will be run.
+			<tt>zerofree</tt>: Specifies if it should mark unallocated blocks as zeroes, so the volume could be better shrunk after this. 
+			<span class="valid-enum label label-primary">true, false</span>
+			<span class="default label label-default">false</span>
 			<span class="optional label label-success"></span>
 		</li>
 		<li>


### PR DESCRIPTION
Anders,

I've updated the documentation about the `minimize_size` settings on plugins page, as it was saying that it expects a path (string), were it should be a boolean value, as I told to you on [this comment](https://github.com/andsens/bootstrap-vz/pull/34#issuecomment-38472907).

Regards,
Tiago.
