### PR TITLE
Add Jekyll-generated files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.pyc
+# Jekyll-generated files
+Gemfile.lock
+_site/
 # When developing for ec2 `vagrant provision' is quite handy
 /Vagrantfile
 /.vagrant


### PR DESCRIPTION
Anders,

Sorry about the third PR in a row, but I've noticed that every time I edit the documentation on the `gh-pages` branch, the files generated by Jekyll remains on the working tree.

Regards,
Tiago.
