### PR TITLE
Add console output to serial when using grub

### DIFF
--- a/common/task_sets.py
+++ b/common/task_sets.py
@@ -74,7 +74,7 @@ locale_set = [locale.LocaleBootstrapPackage,
               ]
 
 
-bootloader_set = {'grub':     [boot.AddGrubPackage, boot.InstallGrub],
+bootloader_set = {'grub':     [boot.AddGrubPackage, boot.ConfigureGrub, boot.InstallGrub],
                   'extlinux': [boot.AddExtlinuxPackage, boot.InstallExtLinux],
                   }
 

--- a/common/tasks/boot.py
+++ b/common/tasks/boot.py
@@ -44,6 +44,20 @@ class AddGrubPackage(Task):
 		info.packages.add('grub-pc')
 
 
+class ConfigureGrub(Task):
+        description = 'Configuring grub'
+        phase = phases.system_modification
+        predecessors = [filesystem.FStab]
+
+        @classmethod
+        def run(cls, info):
+                from common.tools import sed_i
+                grub_def = os.path.join(info.root, 'etc/default/grub')
+                sed_i(grub_def, '^#GRUB_TERMINAL=console', 'GRUB_TERMINAL=console')
+                sed_i(grub_def, '^GRUB_CMDLINE_LINUX_DEFAULT="quiet"',
+                        'GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0"')
+
+
 class InstallGrub(Task):
 	description = 'Installing grub'
 	phase = phases.system_modification


### PR DESCRIPTION
In order to ensure that the console output during boot is output to the serial port, and therefore into the hypervisor log, the serial output has been included in the grub config.
