### PR TITLE
Don't check Guest Additions installation status

### DIFF
--- a/providers/virtualbox/tasks/guest_additions.py
+++ b/providers/virtualbox/tasks/guest_additions.py
@@ -52,8 +52,7 @@ class InstallGuestAdditions(Task):
 
 		install_script = os.path.join('/', mount_dir, 'VBoxLinuxAdditions.run')
 		from common.tools import log_call
-		status, out, err = log_call(['chroot', info.root,
-		                            install_script, '--nox11'])
+		log_call(['chroot', info.root, install_script, '--nox11'])
 
 		log_call(['chroot', info.root, 'service', 'vboxadd-service', 'stop'])
 		root.remove_mount(mount_path)


### PR DESCRIPTION
I've been discussing that with Anders for over a week and we agreed that
checking the return code of the Guest Additions installation is just a
waste of time. It seems to return 1 no matter what happen, like:
- It has been launched without administrator privileges: OK
- Requirements like bzip2 and gcc are missing: OK
- Kernel headers or dkms are missing: OK
- It was installed successfully, but without X11 drivers: ???

There isn't even a way (at least until the current 4.3.x version) to
disable the X11 drivers installation. The `--nox11` option, just "Do not
spawn an xterm".

And the worst part: until the version 4.2.x, it returned 0 if it could
be installed with no errors beside this one about the missing X11
drivers. This means that this verification will most likely fail on any
other version older than 4.3.x, preventing the build from finishing in a
successful way. So, we can't really rely on its return code whatsoever.

That said, neither him or me likes the idea of ignoring the return code
of a command. It just happens that we can't do anything about that.
