### PR TITLE
Comment the usage of log_call()

### DIFF
--- a/providers/virtualbox/tasks/guest_additions.py
+++ b/providers/virtualbox/tasks/guest_additions.py
@@ -51,9 +51,10 @@ class InstallGuestAdditions(Task):
 		root.add_mount(guest_additions_path, mount_path, ['-o', 'loop'])
 
 		install_script = os.path.join('/', mount_dir, 'VBoxLinuxAdditions.run')
+		# Don't check the return code of the scripts here, because 1 not necessarily means they have failed
 		from common.tools import log_call
 		log_call(['chroot', info.root, install_script, '--nox11'])
-
+		# VBoxService process could be running, as it is not affected by DisableDaemonAutostart
 		log_call(['chroot', info.root, 'service', 'vboxadd-service', 'stop'])
 		root.remove_mount(mount_path)
 		os.rmdir(mount_path)


### PR DESCRIPTION
Add two comments to the InstallGuestAdditions, explaining why its return
code will not be checked with `log_check_call()` or even manually
grabbing the status informed by `log_call()` itself.

Previously discussed on the #55 issue and 43e3d96 commit.
