### PR TITLE
Added YAML config support.

### DIFF
--- a/bootstrapvz/base/manifest.py
+++ b/bootstrapvz/base/manifest.py
@@ -3,7 +3,7 @@ to determine which tasks should be added to the tasklist, what arguments various
 invocations should have etc..
 .. module:: manifest
 """
-from bootstrapvz.common.tools import load_json
+from bootstrapvz.common.tools import load_json, load_yaml
 import logging
 log = logging.getLogger(__name__)
 
@@ -34,7 +34,11 @@ class Manifest(object):
 		"""
 		# Load the manifest JSON using the loader in common.tools
 		# It strips comments (which are invalid in strict json) before loading the data.
-		self.data = load_json(self.path)
+		if self.path.endswith('.json'):
+			self.data = load_json(self.path)
+		elif self.path.endswith('.yml') or self.path.endswith('.yaml'):
+			self.data = load_yaml(self.path)
+
 		# Get the provider name from the manifest and load the corresponding module
 		provider_modname = 'bootstrapvz.providers.{provider}'.format(provider=self.data['provider'])
 		log.debug('Loading provider `{modname}\''.format(modname=provider_modname))

--- a/bootstrapvz/common/tools.py
+++ b/bootstrapvz/common/tools.py
@@ -63,6 +63,10 @@ def load_json(path):
 	with open(path) as stream:
 		return json.loads(json_minify(stream.read(), False))
 
+def load_yaml(path):
+	import yaml
+	with open(path, 'r') as fobj:
+		return yaml.load(fobj)
 
 def config_get(path, config_path):
 	config = load_json(path)

--- a/manifests/ec2-ebs-debian-testing-amd64-pvm.manifest.yml
+++ b/manifests/ec2-ebs-debian-testing-amd64-pvm.manifest.yml
@@ -1,0 +1,36 @@
+---
+provider: "ec2"
+virtualization: "pvm"
+credentials:
+    access-key: null
+    secret-key: null
+bootstrapper:
+    workspace: "/target"
+image:
+    name: "debian-{system.release}-{system.architecture}-{virtualization}-{%Y}-{%m}-{%d}-ebs"
+    description: "Debian {system.release} {system.architecture}"
+system:
+    release: "testing"
+    architecture: "amd64"
+    bootloader: "pvgrub"
+    timezone: "UTC"
+    locale: "en_US"
+    charmap: "UTF-8"
+packages:
+    #mirror: "http://cloudfront.debian.net/debian"
+    install_standard: true
+volume:
+    backing: "ebs"
+    partitions:
+        type: "none"
+        root:
+            size: "8GiB"
+            filesystem: "ext4"
+plugins:
+    cloud_init:
+        username: "admin"
+        #metadata_sources: "Ec2"
+        disable_modules:
+            - "landscape"
+            - "byobu"
+            - "ssh-import-id"


### PR DESCRIPTION
- Manifest format parsing is now checked by the file extension ie: .json, .yml or .yaml.
- load_yaml in common/tools is the same as the json version.
- schema checking of manifest still passes (and fails appropriately) like the json manifests.
- I've also included a sample yaml config based off of the debian test json manifest.
