### PR TITLE
Updates on Azure provider to get waagent archive instead of git repo, and add specific configuration in manifest, system section

### DIFF
--- a/bootstrapvz/providers/azure/README.md
+++ b/bootstrapvz/providers/azure/README.md
@@ -2,13 +2,14 @@ Azure provider
 ===========
 
 This provider generates raw images for Microsoft Azure computing platform.
-It also supports an optional virtio integration.
 
 Setup
 =====
 
 qemu-img >= 1.7.0 required to convert raw image to vhd fixed size disk.
 This release is available in wheezy-backports.
+
+*wget* must be installed on local computer.
 
 
 Manifest must use the *raw* format, provider will automatically transform the disk to a vhd disk format.
@@ -25,4 +26,11 @@ The Windows Azure Linux Agent can automatically configure swap space using the l
 
 You can specify a waagent.conf file to replace the default one in the manifest in the azure/waagent section of the provider:
 
-    "azure" : { "waagent" : "path_to_my_conf_file" }, ...
+    "system" : { 
+        "waagent" : {
+           "conf": "path_to_my_conf_file",  # optional
+           "version" : "2.0.4"              # mandatory
+        }
+    }, ...
+
+Waagent versions are available at: https://github.com/Azure/WALinuxAgent/releases

--- a/bootstrapvz/providers/azure/manifest-schema.json
+++ b/bootstrapvz/providers/azure/manifest-schema.json
@@ -3,22 +3,27 @@
 	"title": "Azure manifest",
 	"type": "object",
 	"properties": {
-		"azure": {
-			"type": "object",
-			"properties": {
-				"waagent": {
-					"type": "string"
-				}
-			}
-		},
 		"system": {
 			"type": "object",
 			"properties": {
 				"bootloader": {
 					"type": "string",
 					"enum": ["grub", "extlinux"]
+				},
+				"waagent": {
+					"type": "object",
+					"properties": {
+						"conf": {
+							"type": "string"
+						},
+						"version": {
+							"type": "string"
+						}
+					},
+					"required": ["version"]
 				}
-			}
+			},
+			"required": ["waagent"]
 		},
 		"volume": {
 			"type": "object",

--- a/bootstrapvz/providers/azure/tasks/packages.py
+++ b/bootstrapvz/providers/azure/tasks/packages.py
@@ -18,7 +18,6 @@ class DefaultPackages(Task):
 		info.packages.add('python-openssl')
 		info.packages.add('openssh-server')
 		info.packages.add('python-pyasn1')
-		info.packages.add('git')
 		info.packages.add('sudo')
 		#info.packages.add('waagent')
 
@@ -29,23 +28,30 @@ class Waagent(Task):
 
 	@classmethod
 	def run(cls, info):
-		from bootstrapvz.common.tools import log_call
+		from bootstrapvz.common.tools import log_check_call
 		import os
-		env = os.environ.copy()
-		env['GIT_SSL_NO_VERIFY'] = 'true'
-		status, out, err = log_call(['chroot', info.root,
-         'git','clone', 'https://github.com/WindowsAzure/WALinuxAgent.git',
-         '/root/WALinuxAgent'], env=env)
-		status, out, err = log_call(['chroot', info.root,
-         'cp','/root/WALinuxAgent/waagent','/usr/sbin/waagent'])
-		status, out, err = log_call(['chroot', info.root,
+		waagent_version = info.manifest.system['waagent']['version']
+		waagent_file = 'WALinuxAgent-'+waagent_version+'.tar.gz'
+		waagent_url = 'https://github.com/Azure/WALinuxAgent/archive/' + waagent_file
+		log_check_call(['/usr/bin/wget', '-P', info.root, waagent_url])
+		import os.path
+		waagent_directory = os.path.join(info.root, 'root')
+		log_check_call(['/bin/tar', 'xaf',
+         os.path.join(info.root, waagent_file), '-C', waagent_directory])
+		os.remove(os.path.join(info.root, waagent_file))
+		waagent_script = '/root/WALinuxAgent-WALinuxAgent-' + \
+         waagent_version + '/waagent'
+		log_check_call(['chroot', info.root,
+         'cp',waagent_script, '/usr/sbin/waagent'])
+		log_check_call(['chroot', info.root,
          'chmod','755','/usr/sbin/waagent'])
-		status, out, err = log_call(['chroot', info.root,
+		log_check_call(['chroot', info.root,
           '/usr/sbin/waagent','-install'])
 		import os.path
-		if hasattr(info.manifest, 'azure') and info.manifest.azure['waagent']:
-			if os.path.isfile(info.manifest.azure['waagent']):
-				status, out, err = log_call(['cp',
-                                    info.manifest.azure['waagent'],
+		if 'conf' in info.manifest.system['waagent'] and \
+            info.manifest.system['waagent']['conf']:
+			if os.path.isfile(info.manifest.system['waagent']['conf']):
+				log_check_call(['cp',
+                                    info.manifest.system['waagent']['conf'],
                                     os.path.join(info.root,'etc/waagent.conf')])
 

--- a/manifests/azure.manifest.json
+++ b/manifests/azure.manifest.json
@@ -14,7 +14,10 @@
 		"bootloader":   "grub",
 		"timezone":     "UTC",
 		"locale":       "en_US",
-		"charmap":      "UTF-8"
+		"charmap":      "UTF-8",
+		"waagent": {
+			"version":  "2.0.4"
+		}
 	},
 	"packages": {
 	},


### PR DESCRIPTION
Download Waagent archive instead of using git repo.
Specify the version in the manifest (system/waagent section)
Add possibility to specify waagent conf file in manifest (system/waagent section)
Update documentation to match changes

Use log_check_call instead of log_call
