### PR TITLE
Add missing unstable configuration fixing EC2 image building problems.

### DIFF
--- a/bootstrapvz/common/tasks/apt.py
+++ b/bootstrapvz/common/tasks/apt.py
@@ -28,9 +28,9 @@ class AddDefaultSources(Task):
 			sections = ' '.join(info.manifest.system['sections'])
 		info.source_lists.add('main', 'deb     {apt_mirror} {system.release} '+sections)
 		info.source_lists.add('main', 'deb-src {apt_mirror} {system.release} '+sections)
-		info.source_lists.add('main', 'deb     http://security.debian.org/  {system.release}/updates '+sections)
-		info.source_lists.add('main', 'deb-src http://security.debian.org/  {system.release}/updates '+sections)
-		if info.manifest.system['release'] not in {'testing', 'unstable'}:
+		if info.release_codename != 'sid':
+			info.source_lists.add('main', 'deb     http://security.debian.org/  {system.release}/updates '+sections)
+			info.source_lists.add('main', 'deb-src http://security.debian.org/  {system.release}/updates '+sections)
 			info.source_lists.add('main', 'deb     {apt_mirror} {system.release}-updates ' + sections)
 			info.source_lists.add('main', 'deb-src {apt_mirror} {system.release}-updates ' + sections)
 

--- a/bootstrapvz/common/tasks/network-configuration.json
+++ b/bootstrapvz/common/tasks/network-configuration.json
@@ -8,5 +8,7 @@
 "wheezy": ["auto eth0",
            "iface eth0 inet dhcp"],
 "jessie": ["auto eth0",
+           "iface eth0 inet dhcp"],
+"sid": ["auto eth0",
            "iface eth0 inet dhcp"]
 }

--- a/bootstrapvz/providers/ec2/tasks/packages-kernels.json
+++ b/bootstrapvz/providers/ec2/tasks/packages-kernels.json
@@ -8,5 +8,8 @@
 	 "amd64": "linux-image-amd64"},
 "jessie":
 	{"i386":  "linux-image-686",
+	 "amd64": "linux-image-amd64"},
+"sid":
+	{"i386":  "linux-image-686",
 	 "amd64": "linux-image-amd64"}
 }


### PR DESCRIPTION
I've added missing configuration for kernel packages and networking interfaces; without it I was getting errors when building image.
I've also disabled adding of sources for security updates in unstable; otherwise apt-get update was getting 404 and returning with 100 error, causing image build to fail.
