### PR TITLE
AptUpdate has to explicitly depend on WritePreferences

### DIFF
--- a/bootstrapvz/common/tasks/apt.py
+++ b/bootstrapvz/common/tasks/apt.py
@@ -76,7 +76,6 @@ class WriteSources(Task):
 class WritePreferences(Task):
 	description = 'Writing aptitude preferences to disk'
 	phase = phases.package_installation
-	predecessors = [WriteSources]
 
 	@classmethod
 	def run(cls, info):
@@ -110,7 +109,7 @@ class DisableDaemonAutostart(Task):
 class AptUpdate(Task):
 	description = 'Updating the package cache'
 	phase = phases.package_installation
-	predecessors = [locale.GenerateLocale, WritePreferences]
+	predecessors = [locale.GenerateLocale, WriteSources, WritePreferences]
 
 	@classmethod
 	def run(cls, info):


### PR DESCRIPTION
Hi,

I fixed a bug w/ regards to APT preferences.
`AptUpdate` did not explicitly depend on `WritePreferences`, so apt might run w/o having written the preferences.

Cheers,
Jan
