### PR TITLE
pip_install plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2014-06-06:
+	Ilya Margolin:
+		* pip_install plugin
 2014-05-04:
 	Dhananjay Balan:
 		* Salt minion installation & configuration plugin

--- a/bootstrapvz/plugins/pip_install/__init__.py
+++ b/bootstrapvz/plugins/pip_install/__init__.py
@@ -1,0 +1,12 @@
+import tasks
+
+
+def validate_manifest(data, validator, error):
+	import os.path
+	schema_path = os.path.normpath(os.path.join(os.path.dirname(__file__), 'manifest-schema.json'))
+	validator(data, schema_path)
+
+
+def resolve_tasks(taskset, manifest):
+	taskset.add(tasks.AddPipPackage)
+	taskset.add(tasks.PipInstallCommand)

--- a/bootstrapvz/plugins/pip_install/manifest-schema.json
+++ b/bootstrapvz/plugins/pip_install/manifest-schema.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Pip install plugin manifest",
+	"type": "object",
+	"properties": {
+		"plugins": {
+			"type": "object",
+			"properties": {
+				"pip_install": {
+					"type": "object",
+					"properties": {
+						"packages": { "$ref": "#/definitions/packages" }
+					},
+					"minProperties": 1,
+					"additionalProperties": false
+				}
+			}
+		}
+	},
+	"definitions": {
+		"packages": {
+			"type":    "array",
+			"items": {
+				"type": "string"
+			},
+			"minItems": 1,
+			"uniqueItems": true
+		}
+	}
+}

--- a/bootstrapvz/plugins/pip_install/tasks.py
+++ b/bootstrapvz/plugins/pip_install/tasks.py
@@ -1,0 +1,31 @@
+from bootstrapvz.base import Task
+from bootstrapvz.common import phases
+from bootstrapvz.common.tasks import network
+from bootstrapvz.common.tasks import packages
+from bootstrapvz.common.tasks import apt
+
+
+class AddPipPackage(Task):
+	description = 'Adding `pip\' and Co. to the image packages'
+	phase = phases.preparation
+	predecessors = [apt.AddDefaultSources]
+	successors = [packages.InstallPackages]
+
+	@classmethod
+	def run(cls, info):
+		for package_name in ('python-pip', 'build-essential', 'python-dev'):
+			info.packages.add(package_name)
+
+
+class PipInstallCommand(Task):
+	description = 'Install python packages from pypi with pip'
+	phase = phases.system_modification
+	successors = [network.RemoveDNSInfo]
+
+	@classmethod
+	def run(cls, info):
+		from bootstrapvz.common.tools import log_check_call
+		packages = info.manifest.plugins['pip_install']['packages']
+		pip_install_command = ['chroot', info.root, 'pip', 'install']
+		pip_install_command.extend(packages)
+		log_check_call(pip_install_command)


### PR DESCRIPTION
It installs Python packages from pypi into the bootstrapped system.

Configuration looks like

``` json
{
//...
    "plugins": {
        "pip_install": {"packages": ["a_package", "another_package==1.0.1"]}
    }
}
```

It installs `build-essential` and `python-dev`, so Python extension modules can be built.

See discussion in #103 and docs in #105
