### PR TITLE
Enable the memory cgroup in GCE.

### DIFF
--- a/bootstrapvz/providers/gce/tasks/boot.py
+++ b/bootstrapvz/providers/gce/tasks/boot.py
@@ -5,7 +5,7 @@ import os.path
 
 
 class ConfigureGrub(Task):
-	description = 'Change grub configuration to allow for ttyS0 output'
+	description = 'Change grub configuration to allow for ttyS0 output and enable the memory cgroup'
 	phase = phases.system_modification
 	successors = [boot.InstallGrub]
 
@@ -13,5 +13,5 @@ class ConfigureGrub(Task):
 	def run(cls, info):
 		from bootstrapvz.common.tools import sed_i
 		grub_config = os.path.join(info.root, 'etc/default/grub')
-		sed_i(grub_config, r'^(GRUB_CMDLINE_LINUX*=".*)"\s*$', r'\1console=ttyS0,38400n8"')
+		sed_i(grub_config, r'^(GRUB_CMDLINE_LINUX*=".*)"\s*$', r'\1console=ttyS0,38400n8 cgroup_enable=memory"')
 		sed_i(grub_config, r'^.*(GRUB_TIMEOUT=).*$', r'GRUB_TIMEOUT=0')


### PR DESCRIPTION
Will allow GCE images to enable the memory cgroup for tracking and
enforcement of memory usage and limits. Used extensively by Docker as well as cAdvisor.
