### PR TITLE
Enable the memory cgroup for the Docker plugin.

### DIFF
--- a/bootstrapvz/plugins/docker_daemon/__init__.py
+++ b/bootstrapvz/plugins/docker_daemon/__init__.py
@@ -21,3 +21,4 @@ def resolve_tasks(taskset, manifest):
 	taskset.add(tasks.AddDockerDeps)
 	taskset.add(tasks.AddDockerBinary)
 	taskset.add(tasks.AddDockerInit)
+	taskset.add(tasks.EnableMemoryCgroup)


### PR DESCRIPTION
This will allow for the enforcement and tracking of memory limits and usage.
