### PR TITLE
Fix ephemeral mounts

### DIFF
--- a/bootstrapvz/providers/ec2/manifest-schema.json
+++ b/bootstrapvz/providers/ec2/manifest-schema.json
@@ -9,6 +9,9 @@
 			"properties": {
 				"description": {
 					"type": "string"
+				},
+			"ephemerals": {
+				"type": "boolean"
 				}
 			}
 		},


### PR DESCRIPTION
Add all possible ephemeral block mounts during AMI registration

Value for this being if not using directly AWS to launch a server (ergo skipping the assignment).

Prime case is Rightscale: they create their images with 1-4 ephemeral mounts. Due to this on some instance sizes you don't see all the available ephemeral storage and there is no way to add it afterwards.