### PR TITLE
Do not require AWS credentials in manifest file

### DIFF
--- a/bootstrapvz/providers/ec2/tasks/connection.py
+++ b/bootstrapvz/providers/ec2/tasks/connection.py
@@ -29,6 +29,15 @@ class GetCredentials(Task):
 			for key in keys:
 				creds[key] = getenv(env_key(key))
 			return creds
+
+		def provider_key(key):
+			return key.replace('-', '_')
+		import boto.provider
+		provider = boto.provider.Provider('aws')
+		if all(getattr(provider, provider_key(key)) is not None for key in keys):
+			for key in keys:
+				creds[key] = getattr(provider, provider_key(key))
+			return creds
 		raise RuntimeError(('No ec2 credentials found, they must all be specified '
 		                    'exclusively via environment variables or through the manifest.'))
 


### PR DESCRIPTION
Boto allows for storing credentials in ~/.boto file; user those
if user has not provider one in manifest file.
