### PR TITLE
Improvement in grub options for ec2

### DIFF
--- a/bootstrapvz/providers/ec2/tasks/boot.py
+++ b/bootstrapvz/providers/ec2/tasks/boot.py
@@ -44,7 +44,7 @@ class ConfigurePVGrub(Task):
 		sed_i(grub_def, '^GRUB_TIMEOUT=[0-9]+', 'GRUB_TIMEOUT=0\n'
 		                                        'GRUB_HIDDEN_TIMEOUT=true')
 		sed_i(grub_def, '^#GRUB_TERMINAL=console', 'GRUB_TERMINAL=console')
-		sed_i(grub_def, '^GRUB_CMDLINE_LINUX_DEFAULT="quiet"', 'GRUB_CMDLINE_LINUX_DEFAULT="console=hvc0"')
+		sed_i(grub_def, '^GRUB_CMDLINE_LINUX_DEFAULT=.*', 'GRUB_CMDLINE_LINUX_DEFAULT="consoleblank=0 console=hvc0 elevator=noop"')
 
 		from bootstrapvz.common.tools import log_check_call
 		log_check_call(['chroot', info.root, 'update-grub'])


### PR DESCRIPTION
- Be more robust when setting GRUB_CMDLINE_LINUX_DEFAULT
  - Some Ubuntu releases use GRUB_CMDLINE_LINUX_DEFAULT="quiet splash" and it gets missed
- Stop console from blanking
- Switch elevator to noop as disks are not real disks and this yields better performance.
