### PR TITLE
Fix list of tasks and their ordering

### DIFF
--- a/bootstrapvz/common/tasks/network.py
+++ b/bootstrapvz/common/tasks/network.py
@@ -5,7 +5,7 @@ import os
 
 class RemoveDNSInfo(Task):
 	description = 'Removing resolv.conf'
-	phase = phases.system_modification
+	phase = phases.system_cleaning
 
 	@classmethod
 	def run(cls, info):
@@ -15,7 +15,7 @@ class RemoveDNSInfo(Task):
 
 class RemoveHostname(Task):
 	description = 'Removing the hostname file'
-	phase = phases.system_modification
+	phase = phases.system_cleaning
 
 	@classmethod
 	def run(cls, info):

--- a/bootstrapvz/plugins/puppet/tasks.py
+++ b/bootstrapvz/plugins/puppet/tasks.py
@@ -1,7 +1,6 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import apt
-from bootstrapvz.common.tasks import network
 from bootstrapvz.common.tools import sed_i
 import os
 
@@ -62,7 +61,6 @@ class ApplyPuppetManifest(Task):
 	description = 'Applying puppet manifest'
 	phase = phases.system_modification
 	predecessors = [CopyPuppetAssets]
-	successors = [network.RemoveHostname, network.RemoveDNSInfo]
 
 	@classmethod
 	def run(cls, info):

--- a/bootstrapvz/providers/gce/__init__.py
+++ b/bootstrapvz/providers/gce/__init__.py
@@ -37,6 +37,7 @@ def resolve_tasks(taskset, manifest):
 	                tasks.configuration.GatherReleaseInformation,
 
 	                tasks.host.DisableIPv6,
+	                tasks.host.SetHostname,
 	                tasks.boot.ConfigureGrub,
 	                initd.InstallInitScripts,
 	                ssh.AddSSHKeyGeneration,

--- a/bootstrapvz/providers/gce/tasks/apt.py
+++ b/bootstrapvz/providers/gce/tasks/apt.py
@@ -1,6 +1,7 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import apt
+from bootstrapvz.common.tasks import network
 from bootstrapvz.common.tools import log_check_call
 import os
 
@@ -8,7 +9,7 @@ import os
 class SetPackageRepositories(Task):
 	description = 'Adding apt sources'
 	phase = phases.preparation
-	successors = [apt.AddManifestSources]
+	predecessors = [apt.AddManifestSources]
 
 	@classmethod
 	def run(cls, info):
@@ -39,7 +40,7 @@ class ImportGoogleKey(Task):
 class CleanGoogleRepositoriesAndKeys(Task):
 	description = 'Removing Google key and apt source files'
 	phase = phases.system_cleaning
-	successors = [apt.AptClean]
+	successors = [apt.AptClean, network.RemoveDNSInfo]
 
 	@classmethod
 	def run(cls, info):


### PR DESCRIPTION
- GCE provider wasn't including the GCE SetHostname task, without which
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=604883 was
  preventing the hostname from getting set after reboot.
- During the GCE build, one of the GCE cleaning tasks was trying to run
  an apt-get update after the build-time resolv.conf file was removed.
  Fix this ordering by moving the network.Remove\* tasks to the
  system_cleaning phase as they should have been all along, and adding
  an appropriate ordering rule for the GCE cleaning task.
- Add the fallback http.debian.net mirror after, not before, our mirror.
- The puppet plugin's ApplyPuppetManifest task specified that it should
  run before the network.Remove\* tasks within the system_modification
  phase. Now that those tasks have been moved to a later phase
  (system_cleaning), remove this dependency. I have no puppet manifest
  to test this change, but am including it in hopes of avoiding a
  breakage there. Hopefully someone who uses puppet can test this or at
  least confirm that it's correct.

I've confirmed that a GCE build completes and boots with this change.
