### PR TITLE
Install ca-certificates on GCE

### DIFF
--- a/bootstrapvz/providers/gce/tasks/packages.py
+++ b/bootstrapvz/providers/gce/tasks/packages.py
@@ -20,6 +20,7 @@ class DefaultPackages(Task):
 		info.packages.add('openssh-client')
 		info.packages.add('openssh-server')
 		info.packages.add('dhcpd')
+		info.packages.add('ca-certificates')
 
 		kernel_packages_path = os.path.join(os.path.dirname(__file__), 'packages-kernels.yml')
 		from bootstrapvz.common.tools import config_get


### PR DESCRIPTION
Needed to fetch GCE startup scripts over HTTPS, among other reasons.
