### PR TITLE
Reinstate hostname hook for GCE

### DIFF
--- a/bootstrapvz/providers/gce/__init__.py
+++ b/bootstrapvz/providers/gce/__init__.py
@@ -36,7 +36,7 @@ def resolve_tasks(taskset, manifest):
 	                tasks.configuration.GatherReleaseInformation,
 
 	                tasks.host.DisableIPv6,
-	                tasks.host.SetHostname,
+	                tasks.host.InstallHostnameHook,
 	                tasks.boot.ConfigureGrub,
 	                initd.InstallInitScripts,
 	                ssh.AddSSHKeyGeneration,

--- a/bootstrapvz/providers/gce/tasks/host.py
+++ b/bootstrapvz/providers/gce/tasks/host.py
@@ -17,12 +17,25 @@ class DisableIPv6(Task):
 			print >>config_file, "net.ipv6.conf.all.disable_ipv6 = 1"
 
 
-class SetHostname(Task):
-	description = "Setting hostname"
+class InstallHostnameHook(Task):
+	description = "Installing hostname hook"
 	phase = phases.system_modification
 
 	@classmethod
 	def run(cls, info):
+		# There's a surprising amount of software out there which doesn't react well to the system
+		# hostname being set to a potentially long the fully qualified domain name, including Java 7
+		# and lower, quite relevant to a lot of cloud use cases such as Hadoop. Since Google Compute
+		# Engine's out-of-the-box domain names are long but predictable based on project name, we
+		# install this hook to set the hostname to the short hostname but add a suitable /etc/hosts
+		# entry.
+		#
+		# Since not all operating systems which Google supports on Compute Engine work with the
+		# /etc/dhcp/dhclient-exit-hooks.d directory, Google's internally-built packaging uses the
+		# consistent install path of /usr/share/google/set-hostname, and OS-specific build steps are
+		# used to activate the DHCP hook. In any future Debian-maintained distro-specific packaging,
+		# the updated deb could handle installing the below symlink or the script itself into
+		# /etc/dhcp/dhclient-exit-hooks.d.
 		log_check_call(['chroot', info.root, 'ln', '-s',
 		                '/usr/share/google/set-hostname',
 		                '/etc/dhcp/dhclient-exit-hooks.d/set-hostname'])


### PR DESCRIPTION
This DHCP exit hook to shorten the system hostname on GCE was previously
installed by build-debian-cloud and bootstrap-vz, but seems to have been
inadvertently removed in commit c81045cc6e0f6a2c90002ab50219a15c337630f1
as part of a broad cross-cloud cleanup.

In this commit, I'm reinstating the hook with a name change and an
explanatory comment, to reduce the risk of this vanishing accidentally
in the future.

With this commit, bootstrap-vz fully passes GCE's routine automatic validation tests
for the first time! Once this is merged, I'll proceed to build what will hopefully be the
first GCE image officially published to the debian-cloud project built with bootstrap-vz.
We'll allow lots of other internal teams' cases a bit of time to hammer on it first and find
problems our tests might not have caught, just in case.
