### PR TITLE
Add minimize_size with zerofree to reduce vmdk size with minimal dependency

### DIFF
--- a/manifests/virtualbox-vagrant.manifest.yml
+++ b/manifests/virtualbox-vagrant.manifest.yml
@@ -30,3 +30,6 @@ volume:
 packages: {}
 plugins:
   vagrant: {}
+  minimize_size : {
+    zerofree: true
+    }


### PR DESCRIPTION
This should improve the size of base images for vagrant box download by end users.
Worth adding that to example manifest as should be a much needed improvement in most situations.

I thinks depending on zerofree is worth the addition (re. #137) whereas shrink option's dependency on vmware-vdiskmanager may be more problematic.
