### PR TITLE
Fix task ordering to better support customizations

### DIFF
--- a/bootstrapvz/common/tasks/apt.py
+++ b/bootstrapvz/common/tasks/apt.py
@@ -128,7 +128,7 @@ class DisableDaemonAutostart(Task):
 class AptUpdate(Task):
 	description = 'Updating the package cache'
 	phase = phases.package_installation
-	predecessors = [locale.GenerateLocale, WriteSources]
+	predecessors = [locale.GenerateLocale, WriteSources, WritePreferences]
 
 	@classmethod
 	def run(cls, info):

--- a/bootstrapvz/providers/gce/tasks/apt.py
+++ b/bootstrapvz/providers/gce/tasks/apt.py
@@ -9,7 +9,7 @@ import os
 class SetPackageRepositories(Task):
 	description = 'Adding apt sources'
 	phase = phases.preparation
-	predecessors = [apt.AddManifestSources]
+	predecessors = [apt.AddManifestSources, apt.AddBackports]
 
 	@classmethod
 	def run(cls, info):


### PR DESCRIPTION
This ensures that preferences are written before apt update and also ensures
that in GCE the backports are added to the sources before the provider-specific
SetPackageRepositories happens.
