### PR TITLE
allow custom ulimit -n for Docker

### DIFF
--- a/bootstrapvz/plugins/docker_daemon/assets/default/docker
+++ b/bootstrapvz/plugins/docker_daemon/assets/default/docker
@@ -6,6 +6,9 @@
 # Use DOCKER_OPTS to modify the daemon startup options.
 #DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4"
 
+# Use DOCKER_NOFILE to set ulimit -n before starting Docker.
+#DOCKER_NOFILE=65536
+
 # If you need Docker to use an HTTP proxy, it can also be specified here.
 #export http_proxy="http://127.0.0.1:3128/"
 

--- a/bootstrapvz/plugins/docker_daemon/assets/init.d/docker
+++ b/bootstrapvz/plugins/docker_daemon/assets/init.d/docker
@@ -83,6 +83,10 @@ case "$1" in
 		touch "$DOCKER_LOGFILE"
 		chgrp docker "$DOCKER_LOGFILE"
 
+		if [ -n $DOCKER_NOFILE ]; then
+			ulimit -n $DOCKER_NOFILE
+		fi
+
 		log_begin_msg "Starting $DOCKER_DESC: $BASE"
 		start-stop-daemon --start --background \
 			--no-close \


### PR DESCRIPTION
This is something that comes up from time to time, where we need the ability to run Docker with a custom limit on the number of open file descriptors.
