### PR TITLE
fix test for DOCKER_NOFILE

### DIFF
--- a/bootstrapvz/plugins/docker_daemon/assets/init.d/docker
+++ b/bootstrapvz/plugins/docker_daemon/assets/init.d/docker
@@ -83,7 +83,7 @@ case "$1" in
 		touch "$DOCKER_LOGFILE"
 		chgrp docker "$DOCKER_LOGFILE"
 
-		if [ -n $DOCKER_NOFILE ]; then
+		if [ -n "$DOCKER_NOFILE" ]; then
 			ulimit -n $DOCKER_NOFILE
 		fi
 


### PR DESCRIPTION
Previously, if DOCKER_NOFILE was not set, the docker init script would execute "ulimit -n", which is harmless, but not what was intended.
