### PR TITLE
Allow mixed kernel/userspace architecture.

### DIFF
--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -40,6 +40,8 @@ properties:
     properties:
       architecture:
         enum: [i386, amd64]
+      userspace_architecture:
+        enum: [i386]
       bootloader:
         enum:
         - pvgrub

--- a/bootstrapvz/common/tasks/bootstrap.py
+++ b/bootstrapvz/common/tasks/bootstrap.py
@@ -19,7 +19,8 @@ class AddRequiredCommands(Task):
 
 def get_bootstrap_args(info):
 	executable = ['debootstrap']
-	options = ['--arch=' + info.manifest.system['architecture']]
+	arch = info.manifest.system.get('userspace_architecture', info.manifest.system.get('architecture'))
+	options = ['--arch=' + arch]
 	if len(info.include_packages) > 0:
 		options.append('--include=' + ','.join(info.include_packages))
 	if len(info.exclude_packages) > 0:


### PR DESCRIPTION
This is to allow building an image for a 64bit machine but with 32bit userspace.

Probably not a common use-case but ideal if you need to address more higher quantities of memory but cant migrate to a full 64bit userspace due to something like ruby eating twice as much memory.
