### PR TITLE
Add support for enhanced networking on EC2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2014-11-23:
+	Noah Fontes:
+		* Add support for enhanced networking on EC2 images
 2014-07-12:
 	Tiago Ilieve:
 		* Fixes #96: AddBackports is now a common task

--- a/bootstrapvz/common/tasks/kernel.py
+++ b/bootstrapvz/common/tasks/kernel.py
@@ -1,0 +1,26 @@
+from bootstrapvz.base import Task
+from .. import phases
+from ..tasks import packages
+
+
+class AddDKMSPackages(Task):
+	description = 'Adding DKMS and kernel header packages'
+	phase = phases.package_installation
+	successors = [packages.InstallPackages]
+
+	@classmethod
+	def run(cls, info):
+		info.packages.add('dkms')
+		kernel_pkg_arch = {'i386': '686-pae', 'amd64': 'amd64'}[info.manifest.system['architecture']]
+		info.packages.add('linux-headers-' + kernel_pkg_arch)
+
+
+class UpdateInitramfs(Task):
+	description = 'Rebuilding initramfs'
+	phase = phases.system_modification
+
+	@classmethod
+	def run(cls, info):
+		from bootstrapvz.common.tools import log_check_call
+	        # Update initramfs (-u) for all currently installed kernel versions (-k all)
+		log_check_call(['chroot', info.root, 'update-initramfs', '-u', '-k', 'all'])

--- a/bootstrapvz/providers/ec2/manifest-schema.yml
+++ b/bootstrapvz/providers/ec2/manifest-schema.yml
@@ -19,6 +19,10 @@ properties:
         enum:
         - pvm
         - hvm
+      enhanced_networking:
+        enum:
+        - none
+        - simple
     required: [virtualization]
   system:
     type: object

--- a/bootstrapvz/providers/ec2/tasks/ami.py
+++ b/bootstrapvz/providers/ec2/tasks/ami.py
@@ -122,4 +122,7 @@ class RegisterAMI(Task):
 			registration_params['kernel_id'] = config_get(akis_path, [info._ec2['region'],
 			                                                          info.manifest.system['architecture']])
 
+		if 'enhanced_networking' in info.manifest.provider and info.manifest.provider['enhanced_networking'] == 'simple':
+			registration_params['sriov_net_support'] = 'simple'
+
 		info._ec2['image'] = info._ec2['connection'].register_image(**registration_params)

--- a/manifests/ec2-ebs-debian-official-amd64-hvm-cn-north-1.manifest.yml
+++ b/manifests/ec2-ebs-debian-official-amd64-hvm-cn-north-1.manifest.yml
@@ -2,6 +2,7 @@
 provider:
   name: ec2
   virtualization: hvm
+  enhanced_networking: simple
   # credentials:
   #   access-key: AFAKEACCESSKEYFORAWS
   #   secret-key: thes3cr3tkeyf0ryourawsaccount/FS4d8Qdva

--- a/manifests/ec2-ebs-debian-official-amd64-hvm.manifest.yml
+++ b/manifests/ec2-ebs-debian-official-amd64-hvm.manifest.yml
@@ -2,6 +2,7 @@
 provider:
   name: ec2
   virtualization: hvm
+  enhanced_networking: simple
   # credentials:
   #   access-key: AFAKEACCESSKEYFORAWS
   #   secret-key: thes3cr3tkeyf0ryourawsaccount/FS4d8Qdva


### PR DESCRIPTION
Hi all,

I've added support as a plugin for EC2's enhanced networking using the new Intel driver. The steps in the plugin follow the [official EC2 documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html) for enabling it.

The existing enhanced networking installation task wasn't used (and didn't work), so I've also removed that.

On my test instances, enhanced networking reduces latency by 10-20% and jitter by almost 90%.

This feels like something that should be automatically enabled for EC2/HVM configurations, so I'd be happy to refactor it to the EC2 provider as well. I believe Ubuntu enables it by default for HVM.

Thanks!
