### PR TITLE
runs grub-install outside chroot to build jessie/sid on wheezy, fixes #155

### DIFF
--- a/bootstrapvz/common/tasks/boot.py
+++ b/bootstrapvz/common/tasks/boot.py
@@ -105,8 +105,7 @@ class InstallGrub(Task):
 						                         idx=idx + 1))
 
 			# Install grub
-			log_check_call(['chroot', info.root,
-			                'grub-install', device_path])
+			log_check_call(['grub-install', '--root-directory=' + info.root, device_path])
 			log_check_call(['chroot', info.root, 'update-grub'])
 		except Exception as e:
 			if isinstance(info.volume, LoopbackVolume):


### PR DESCRIPTION
This runs grub-install from outside chroot to ensure grub-install succeeds when building a jessie or sid image on a wheezy host, fixing #155 
