### PR TITLE
Fix installation of vbox guest additions.

### DIFF
--- a/bootstrapvz/providers/virtualbox/assets/install_guest_additions.sh
+++ b/bootstrapvz/providers/virtualbox/assets/install_guest_additions.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+function uname {
+  if [[ $1 == '-r' ]]; then
+    echo "KERNEL_VERSION"
+    return 0
+  elif [[ $1 == '-m' ]]; then
+    echo "KERNEL_ARCH"
+    return 0
+  else
+    $(which uname) $@
+  fi
+}
+export -f uname
+
+INSTALL_SCRIPT --nox11


### PR DESCRIPTION
Credits for this idea go to @myhro who suggested emulating uname.

I cleaned his changes up somewhat and moved the script into a
separate file to make things easier to look at.

I did a test build of wheezy with my changes and the modules were
installed correctly.

root@localhost:/home/vagrant# dkms status
vboxguest, 4.3.20, 3.2.0-4-amd64, x86_64: installed

root@localhost:/home/vagrant# lsmod | egrep ^vbox
vboxsf                 33359  0
vboxvideo              12437  0
vboxguest             162115  1 vboxsf