### PR TITLE
Use DOCKER_LOCKEDMEMORY to set ulimit -l before starting Docker. 

### DIFF
--- a/bootstrapvz/plugins/docker_daemon/assets/default/docker
+++ b/bootstrapvz/plugins/docker_daemon/assets/default/docker
@@ -9,6 +9,9 @@
 # Use DOCKER_NOFILE to set ulimit -n before starting Docker.
 #DOCKER_NOFILE=65536
 
+# Use DOCKER_LOCKEDMEMORY to set ulimit -l before starting Docker.
+#DOCKER_LOCKEDMEMORY=unlimited
+
 # If you need Docker to use an HTTP proxy, it can also be specified here.
 #export http_proxy="http://127.0.0.1:3128/"
 

--- a/bootstrapvz/plugins/docker_daemon/assets/init.d/docker
+++ b/bootstrapvz/plugins/docker_daemon/assets/init.d/docker
@@ -87,6 +87,10 @@ case "$1" in
 			ulimit -n $DOCKER_NOFILE
 		fi
 
+		if [ -n "$DOCKER_LOCKEDMEMORY" ]; then
+			ulimit -l $DOCKER_LOCKEDMEMORY
+		fi
+
 		log_begin_msg "Starting $DOCKER_DESC: $BASE"
 		start-stop-daemon --start --background \
 			--no-close \


### PR DESCRIPTION
## Reason:

Running memory heavy applications, such as elastic search, benefit from having locked memory. This can be achieved by using ulimit -l  
## Additions:

Added DOCKER_LOCKEDMEMORY as a var that will allow people to change the settings. This works just like DOCKER_NOFILE, which allows to change number of open file descriptors.
