### PR TITLE
Blacklist floppy module to speed up boot by several seconds.

### DIFF
--- a/bootstrapvz/common/tasks/boot.py
+++ b/bootstrapvz/common/tasks/boot.py
@@ -7,16 +7,28 @@ from bootstrapvz.base.fs import partitionmaps
 import os.path
 
 
+class UpdateInitramfs(Task):
+	description = 'Updating initramfs'
+	phase = phases.system_modification
+
+	@classmethod
+	def run(cls, info):
+		from ..tools import log_check_call
+		log_check_call(['chroot', info.root, 'update-initramfs', '-u'])
+
+
 class BlackListModules(Task):
 	description = 'Blacklisting kernel modules'
 	phase = phases.system_modification
+	successors = [UpdateInitramfs]
 
 	@classmethod
 	def run(cls, info):
 		blacklist_path = os.path.join(info.root, 'etc/modprobe.d/blacklist.conf')
 		with open(blacklist_path, 'a') as blacklist:
-			blacklist.write(('# disable pc speaker\n'
-			                 'blacklist pcspkr'))
+			blacklist.write(('# disable pc speaker and floppy\n'
+			                 'blacklist pcspkr\n'
+			                 'blacklist floppy\n'))
 
 
 class DisableGetTTYs(Task):

--- a/bootstrapvz/providers/gce/__init__.py
+++ b/bootstrapvz/providers/gce/__init__.py
@@ -7,6 +7,7 @@ import tasks.initd
 import tasks.host
 import tasks.packages
 from bootstrapvz.common.tasks import apt
+from bootstrapvz.common.tasks import boot
 from bootstrapvz.common.tasks import loopback
 from bootstrapvz.common.tasks import initd
 from bootstrapvz.common.tasks import ssh
@@ -43,6 +44,8 @@ def resolve_tasks(taskset, manifest):
 	                initd.AddExpandRoot,
 	                tasks.initd.AdjustExpandRootDev,
 	                initd.InstallInitScripts,
+	                boot.BlackListModules,
+	                boot.UpdateInitramfs,
 	                ssh.AddSSHKeyGeneration,
 	                ssh.DisableSSHPasswordAuthentication,
 	                tasks.apt.CleanGoogleRepositoriesAndKeys,


### PR DESCRIPTION
Add UpdateInitramfs task which is needed for this to take effect.
Enable both tasks for GCE.

Console output before
=====================
[    1.877142] sd 0:0:1:0: [sda] Attached SCSI disk
[    1.880163] sd 0:0:1:0: Attached scsi generic sg0 type 0
[    2.684132] tsc: Refined TSC clocksource calibration: 2500.000 MHz
[    4.824081] floppy0: no floppy controllers found
[    5.103671] work still pending
Begin: Loading essential drivers ... done.
Begin: Running /scripts/init-premount ... done.
Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
Begin: Running /scripts/local-premount ... done.
[    5.313107] EXT4-fs (sda1): mounted filesystem with ordered data mode. Opts: (null)
...
[    7.751955] alg: No test for crc32 (crc32-pclmul)
[   10.728078] floppy0: no floppy controllers found
[   11.006680] work still pending
[....] Activating swap... done
[   11.258954] EXT4-fs (sda1): re-mounted. Opts: (null)

Console output after
====================
[    1.829785] sd 0:0:1:0: [sda] Attached SCSI disk
[    1.832806] sd 0:0:1:0: Attached scsi generic sg0 type 0
Begin: Loading essential drivers ... done.
Begin: Running /scripts/init-premount ... done.
Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
Begin: Running /scripts/local-premount ... done.
[    1.969862] EXT4-fs (sda1): mounted filesystem with ordered data mode. Opts: (null)
...
[    2.878920] alg: No test for crc32 (crc32-pclmul)
[....] Activating swap... done
[    2.986642] EXT4-fs (sda1): re-mounted. Opts: (null)

Delint.