### PR TITLE
Recover file permissions after shrink a vmdk image

### DIFF
--- a/bootstrapvz/plugins/minimize_size/tasks.py
+++ b/bootstrapvz/plugins/minimize_size/tasks.py
@@ -81,4 +81,6 @@ class ShrinkVolume(Task):
 	@classmethod
 	def run(cls, info):
 		from bootstrapvz.common.tools import log_check_call
+		perm = os.stat(info.volume.image_path).st_mode & 0777
 		log_check_call(['/usr/bin/vmware-vdiskmanager', '-k', info.volume.image_path])
+		os.chmod(info.volume.image_path, perm)


### PR DESCRIPTION
After vmware-vdiskmanager runs, the image is left with a 600
permission. This commit fixes it by preserving the file permission
before the shrink operation.