### PR TITLE
Disable resize on disks larger than 2TB

### DIFF
--- a/bootstrapvz/providers/gce/__init__.py
+++ b/bootstrapvz/providers/gce/__init__.py
@@ -9,6 +9,7 @@ import tasks.packages
 from bootstrapvz.common.tasks import apt
 from bootstrapvz.common.tasks import loopback
 from bootstrapvz.common.tasks import initd
+from bootstrapvz.common.tasks import kernel
 from bootstrapvz.common.tasks import ssh
 from bootstrapvz.common.tasks import volume
 
@@ -54,6 +55,10 @@ def resolve_tasks(taskset, manifest):
 
 	if manifest.volume['partitions']['type'] != 'none':
 		taskset.add(initd.AdjustExpandRootScript)
+
+	if manifest.volume['partitions']['type'] != 'mbr':
+		taskset.update([tasks.initd.AddGrowRootDisable,
+		                kernel.UpdateInitramfs])
 
 	if 'gcs_destination' in manifest.image:
 		taskset.add(tasks.image.UploadImage)

--- a/bootstrapvz/providers/gce/assets/initramfs-tools/scripts/local-premount/gce-disable-growroot
+++ b/bootstrapvz/providers/gce/assets/initramfs-tools/scripts/local-premount/gce-disable-growroot
@@ -1,0 +1,52 @@
+# Selectively disable growroot               -*- shell-script -*-
+set -e
+
+message() { echo "DISABLE-GROWROOT:" "$@" ; }
+error_exit() { message "$@"; exit 1; }
+
+. /scripts/functions
+
+# initramfs-tools exports the following variables, used below:
+# $ROOT - Generally "/dev/disk/by-uuid/<id>" which is a link to /dev/sda1
+# $ROOTFLAGS - Generally empty
+# $ROOTFSTYPE - Generally empty
+# $rootmnt - Set to "/root"
+
+# Follow link to get real root location
+if [ ! -L "${ROOT}" ]; then
+  real_root=${ROOT}
+else
+  real_root=$(readlink -f "${ROOT}")
+fi
+
+# Remove partition number to get disk
+disk=$(echo ${real_root} | sed 's/[0-9]*$//')
+
+# Determine number of 512-byte sectors in 2TB
+two_tb=$((2*(1024**4)))
+max_sectors=$((${two_tb}/512))
+
+# Determine number of sectors on disk
+geometry=$(sfdisk ${disk} --show-pt-geometry)
+cyl=$(echo $geometry | cut -d " " -f 2)
+heads=$(echo $geometry | cut -d " " -f 4)
+secs=$(echo $geometry | cut -d " " -f 6)
+sectors=$((${cyl}*${heads}*${secs}))
+
+# If disk is >2TB, disable growroot
+if [ "$sectors" -gt "$max_sectors" ]; then
+  message "Disk size >2TB - Not expanding root partition"
+  # Temporarily mount filesystem
+  if [ -z "${ROOTFSTYPE}" ]; then
+    fstype=$(get_fstype "${ROOT}")
+  else
+    fstype=${ROOTFSTYPE}
+  fi
+  mount -w ${fstype:+-t ${fstype} }${ROOTFLAGS} ${ROOT} ${rootmnt} ||
+      error_exit "failed to mount ${ROOT}."
+  # Disable growroot
+  touch "${rootmnt}/etc/growroot-disabled"
+  # Unmount filesystem
+  umount "${rootmnt}" || error_exit "failed to umount ${rootmnt}";
+fi
+

--- a/bootstrapvz/providers/gce/tasks/__init__.py
+++ b/bootstrapvz/providers/gce/tasks/__init__.py
@@ -1,0 +1,3 @@
+import os.path
+
+assets = os.path.normpath(os.path.join(os.path.dirname(__file__), '../assets'))

--- a/bootstrapvz/providers/gce/tasks/initd.py
+++ b/bootstrapvz/providers/gce/tasks/initd.py
@@ -1,6 +1,9 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import initd
+from bootstrapvz.common.tasks import kernel
+from . import assets
+import os.path
 
 
 class AdjustExpandRootDev(Task):
@@ -10,7 +13,26 @@ class AdjustExpandRootDev(Task):
 
 	@classmethod
 	def run(cls, info):
-		import os.path
 		from bootstrapvz.common.tools import sed_i
 		script = os.path.join(info.root, 'etc/init.d/expand-root')
 		sed_i(script, '/dev/xvda', '/dev/sda')
+
+
+class AddGrowRootDisable(Task):
+	description = 'Add script to selectively disable growroot'
+	phase = phases.system_modification
+	successors = [kernel.UpdateInitramfs]
+
+	@classmethod
+	def run(cls, info):
+		import stat
+		rwxr_xr_x = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+		             stat.S_IRGRP                | stat.S_IXGRP |
+		             stat.S_IROTH                | stat.S_IXOTH)
+		from shutil import copy
+		script_src = os.path.join(assets,
+                            'initramfs-tools/scripts/local-premount/gce-disable-growroot')
+		script_dst = os.path.join(info.root,
+                            'etc/initramfs-tools/scripts/local-premount/gce-disable-growroot')
+		copy(script_src, script_dst)
+		os.chmod(script_dst, rwxr_xr_x)


### PR DESCRIPTION
This is a temporary fix to work around a bug in Debian where growpart can destroy a disk >2TB since it updates the partition table incorrectly (i.e. it can shrink the partition under some circumstances.

This bug is described in more detail in this thread: https://lists.debian.org/debian-cloud/2014/10/msg00018.html

Once a fix has been submitted to Debian, this change can be reverted.

Quick summary of the change:
This change adds a file to initramfs in /etc/initramfs-tools/scripts/local-premount/ called gce-disable-growroot. This is a shell script that checks the size of the disk and if it's greater than 2TB, it touches the file /etc/disable-growroot on the disk. When growroot discovers that file, it will not attempt to resize the root partition.