### PR TITLE
Add the manifest "include-source-type" key for packages object

### DIFF
--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -121,6 +121,7 @@ properties:
         items:
           $ref: '#/definitions/absolute_path'
         minItems: 1
+      include-source-type: {type: boolean}
     additionalProperties: false
   plugins:
     type: object

--- a/bootstrapvz/common/tasks/apt.py
+++ b/bootstrapvz/common/tasks/apt.py
@@ -24,14 +24,18 @@ class AddDefaultSources(Task):
 
 	@classmethod
 	def run(cls, info):
+		include_src = info.manifest.packages.get('include-source-type', False)
 		components = ' '.join(info.manifest.packages.get('components', ['main']))
 		info.source_lists.add('main', 'deb     {apt_mirror} {system.release} ' + components)
-		info.source_lists.add('main', 'deb-src {apt_mirror} {system.release} ' + components)
+		if include_src:
+			info.source_lists.add('main', 'deb-src {apt_mirror} {system.release} ' + components)
 		if info.release_codename != 'sid':
 			info.source_lists.add('main', 'deb     http://security.debian.org/  {system.release}/updates ' + components)
-			info.source_lists.add('main', 'deb-src http://security.debian.org/  {system.release}/updates ' + components)
+			if include_src:
+				info.source_lists.add('main', 'deb-src http://security.debian.org/  {system.release}/updates ' + components)
 			info.source_lists.add('main', 'deb     {apt_mirror} {system.release}-updates ' + components)
-			info.source_lists.add('main', 'deb-src {apt_mirror} {system.release}-updates ' + components)
+			if include_src:
+				info.source_lists.add('main', 'deb-src {apt_mirror} {system.release}-updates ' + components)
 
 
 class AddBackports(Task):


### PR DESCRIPTION
It controls whether to include the 'deb-src' lines in image's
source.list.

Currently they are always included. This patch changes this
behavior by not including them by default; the user must set
this new config to true in order to include them.

This saves a bit of bandwidth in default installations. Also,
the use of src packages is not so usual in ordinary installations.