### PR TITLE
Switch to using ec2-ami-tools

### DIFF
--- a/bootstrapvz/providers/ec2/tasks/host.py
+++ b/bootstrapvz/providers/ec2/tasks/host.py
@@ -11,8 +11,8 @@ class AddExternalCommands(Task):
 	@classmethod
 	def run(cls, info):
 		if info.manifest.volume['backing'] == 's3':
-			info.host_dependencies['euca-bundle-image'] = 'euca2ools'
-			info.host_dependencies['euca-upload-bundle'] = 'euca2ools'
+			info.host_dependencies['ec2-bundle-image'] = 'ec2-ami-tools'
+			info.host_dependencies['euca-upload-bundle'] = 'ec2-ami-tools'
 
 
 class GetInstanceMetadata(Task):


### PR DESCRIPTION
`bootstrap-vz` was calling `euca-upload-bundle` with an invalid flag `ec2cert` (though the docs say this flag should exist). Rather than fixing the usage of `euca2ools` (I wasn't able to get it to generate a bundle with a valid manifest) it felt better to just use the tools provided by Amazon.

If we like this change, I can update the docs.

This addresses #27, #29, and #30 and part of #101 .