### PR TITLE
Remove --ec2cert from euca-upload-bundle

### DIFF
--- a/bootstrapvz/providers/ec2/tasks/ami.py
+++ b/bootstrapvz/providers/ec2/tasks/ami.py
@@ -71,8 +71,7 @@ class UploadImage(Task):
 		                '--access-key', info.credentials['access-key'],
 		                '--secret-key', info.credentials['secret-key'],
 		                '--url', s3_url,
-		                '--region', info._ec2['region'],
-		                '--ec2cert', cert_ec2])
+		                '--region', info._ec2['region']])
 
 
 class RemoveBundle(Task):


### PR DESCRIPTION
As this flag does not exist. The ec2cert is only useful when building
the bundle.

Tested this with version `3.2.0` and tip of euca2ools.

This is related to #27, #29, and #30 and part of #101.