### PR TITLE
Execute entries with a single string as shell commands

### DIFF
--- a/bootstrapvz/plugins/image_commands/README.md
+++ b/bootstrapvz/plugins/image_commands/README.md
@@ -10,6 +10,12 @@ Plugin is defined in the manifest file, plugin section with:
 
 The *commands* element is an array of commands. Each command is an array describing the executable and its arguments.
 
+If you need shell expansion of wildcards, like __\*__, just put the entire command as a single entry:
+
+    "image_commands": {
+        "commands": [ [ "rm -f /tmp/*" ]],
+    }
+
 Command is executed in current context. It is possible to use variables to access the image or execute chroot commands in the image.
 
 Available variables are:

--- a/bootstrapvz/plugins/image_commands/tasks.py
+++ b/bootstrapvz/plugins/image_commands/tasks.py
@@ -11,4 +11,5 @@ class ImageExecuteCommand(Task):
 		from bootstrapvz.common.tools import log_check_call
 		for raw_command in info.manifest.plugins['image_commands']['commands']:
 			command = map(lambda part: part.format(root=info.root, **info.manifest_vars), raw_command)
-			log_check_call(command)
+			shell = len(command) == 1
+			log_check_call(command, shell=shell)


### PR DESCRIPTION
Documentation says about that, but it's not implemented like that.

If the command to be executed is an array with just one string, it's
likely the user passed the entire command inside the string.

Plus, they benefit from shell expansion of wildcards like '*'.