### PR TITLE
Add authentication support to the apt proxy plugin

### DIFF
--- a/bootstrapvz/plugins/apt_proxy/README.rst
+++ b/bootstrapvz/plugins/apt_proxy/README.rst
@@ -14,6 +14,12 @@ Settings
     *``required``*
 -  ``port``: The port (integer) of the proxy server.
     *``required``*
+-  ``username``: The username for authentication against the proxy server.
+   This is ignored if ``password`` is not also set.
+   *``optional``*
+-  ``password``: The password for authentication against the proxy server.
+   This is ignored if ``username`` is not also set.
+   *``optional``*
 -  ``persistent``: Whether the proxy configuration file should remain on
    the machine or not.
    Valid values: true, false

--- a/bootstrapvz/plugins/apt_proxy/manifest-schema.yml
+++ b/bootstrapvz/plugins/apt_proxy/manifest-schema.yml
@@ -10,8 +10,10 @@ properties:
         type: object
         properties:
           address: {type: string}
+          password: {type: string}
           port: {type: integer}
           persistent: {type: boolean}
+          username: {type: string}
         required:
         - address
         - port

--- a/bootstrapvz/plugins/apt_proxy/tasks.py
+++ b/bootstrapvz/plugins/apt_proxy/tasks.py
@@ -34,11 +34,21 @@ class SetAptProxy(Task):
 	@classmethod
 	def run(cls, info):
 		proxy_path = os.path.join(info.root, 'etc/apt/apt.conf.d/02proxy')
+		proxy_username = info.manifest.plugins['apt_proxy'].get('username')
+		proxy_password = info.manifest.plugins['apt_proxy'].get('password')
 		proxy_address = info.manifest.plugins['apt_proxy']['address']
 		proxy_port = info.manifest.plugins['apt_proxy']['port']
+
+		if None not in (proxy_username, proxy_password):
+			proxy_auth = '{username}:{password}@'.format(
+				username=proxy_username, password=proxy_password)
+		else:
+			proxy_auth = ''
+
 		with open(proxy_path, 'w') as proxy_file:
-			proxy_file.write('Acquire::http {{ Proxy "http://{address}:{port}"; }};\n'
-			                 .format(address=proxy_address, port=proxy_port))
+			proxy_file.write(
+				'Acquire::http {{ Proxy "http://{auth}{address}:{port}"; }};\n'
+				.format(auth=proxy_auth, address=proxy_address, port=proxy_port))
 
 
 class RemoveAptProxy(Task):


### PR DESCRIPTION
Add username and password settings to the APT Proxy plugin so that
users who are behind an authenticating proxy can still use bootstrap-vz
without having to jump through hoops. If either the username or password
are not set, then no authentication is used.