### PR TITLE
root_password: Enable SSH root login

### DIFF
--- a/bootstrapvz/common/tasks/ssh.py
+++ b/bootstrapvz/common/tasks/ssh.py
@@ -51,6 +51,17 @@ class DisableSSHPasswordAuthentication(Task):
 		sed_i(sshd_config_path, '^#PasswordAuthentication yes', 'PasswordAuthentication no')
 
 
+class PermitSSHRootLogin(Task):
+	description = 'Permitting SSH root login'
+	phase = phases.system_modification
+
+	@classmethod
+	def run(cls, info):
+		from ..tools import sed_i
+		sshd_config_path = os.path.join(info.root, 'etc/ssh/sshd_config')
+		sed_i(sshd_config_path, '^PermitRootLogin .*', 'PermitRootLogin yes')
+
+
 class DisableSSHDNSLookup(Task):
 	description = 'Disabling sshd remote host name lookup'
 	phase = phases.system_modification

--- a/bootstrapvz/plugins/root_password/__init__.py
+++ b/bootstrapvz/plugins/root_password/__init__.py
@@ -10,4 +10,5 @@ def resolve_tasks(taskset, manifest):
 	from bootstrapvz.common.tasks import ssh
 	from tasks import SetRootPassword
 	taskset.discard(ssh.DisableSSHPasswordAuthentication)
+	taskset.add(ssh.PermitSSHRootLogin)
 	taskset.add(SetRootPassword)


### PR DESCRIPTION
Jessie comes with root login disabled for passwords, however,
if the user is using this plugin, chances are high that they
need to login via SSH as root.