### PR TITLE
Use SSD volumes instead of magnetic

### DIFF
--- a/bootstrapvz/providers/ec2/ebsvolume.py
+++ b/bootstrapvz/providers/ec2/ebsvolume.py
@@ -12,7 +12,7 @@ class EBSVolume(Volume):
 		conn = e.connection
 		zone = e.zone
 		size = self.size.bytes.get_qty_in('GiB')
-		self.volume = conn.create_volume(size, zone)
+		self.volume = conn.create_volume(size, zone, volume_type='gp2')
 		while self.volume.volume_state() != 'available':
 			time.sleep(5)
 			self.volume.update()

--- a/bootstrapvz/providers/ec2/tasks/ami.py
+++ b/bootstrapvz/providers/ec2/tasks/ami.py
@@ -108,7 +108,7 @@ class RegisterAMI(Task):
 			from boto.ec2.blockdevicemapping import BlockDeviceType
 			from boto.ec2.blockdevicemapping import BlockDeviceMapping
 			block_device = BlockDeviceType(snapshot_id=info._ec2['snapshot'].id, delete_on_termination=True,
-			                               size=info.volume.size.bytes.get_qty_in('GiB'))
+			                               size=info.volume.size.bytes.get_qty_in('GiB'), volume_type='gp2')
 			registration_params['block_device_map'] = BlockDeviceMapping()
 			registration_params['block_device_map'][root_dev_name] = block_device
 


### PR DESCRIPTION
They are faster and the default when using AWS EC2 console.

If you think this is too intrusive, we could add a config parameter to let the user choose the volume type he wants...