### PR TITLE
apt_proxy: Also consider http error code 406

### DIFF
--- a/bootstrapvz/plugins/apt_proxy/tasks.py
+++ b/bootstrapvz/plugins/apt_proxy/tasks.py
@@ -18,7 +18,7 @@ class CheckAptProxy(Task):
 			urllib2.urlopen(proxy_url, timeout=5)
 		except Exception as e:
 			# Default response from `apt-cacher-ng`
-			if isinstance(e, urllib2.HTTPError) and e.code == 404 and e.msg == 'Usage Information':
+			if isinstance(e, urllib2.HTTPError) and e.code in [404, 406] and e.msg == 'Usage Information':
 				pass
 			else:
 				import logging


### PR DESCRIPTION
It seems some Debian versions of apt-cacher-ng return error
code 406 instead of 404:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=762969

This is my case in Jessie, for example.

This patch considers both codes as "valid".