### PR TITLE
Ec2: Add the variable "install_init_scripts"

### DIFF
--- a/bootstrapvz/providers/ec2/README.rst
+++ b/bootstrapvz/providers/ec2/README.rst
@@ -11,7 +11,8 @@ Unless `the cloud-init plugin <../../plugins/cloud_init>`__
 is used, special startup scripts will be installed that automatically fetch the
 configured authorized\_key from the instance metadata and save or run
 any userdata supplied (if the userdata begins with ``#!`` it will be
-run).
+run). Set the variable ``install_init_scripts`` to ``False`` in order
+to disable this behaviour.
 
 Credentials
 -----------

--- a/bootstrapvz/providers/ec2/__init__.py
+++ b/bootstrapvz/providers/ec2/__init__.py
@@ -68,11 +68,13 @@ def resolve_tasks(taskset, manifest):
 	                tasks.network.EnableDHCPCDDNS,
 	                initd.AddExpandRoot,
 	                initd.RemoveHWClock,
-	                tasks.initd.AddEC2InitScripts,
 	                initd.InstallInitScripts,
 
 	                tasks.ami.RegisterAMI,
 	                ])
+
+	if manifest.provider.get('install_init_scripts', True):
+		taskset.add(tasks.initd.AddEC2InitScripts)
 
 	if manifest.volume['partitions']['type'] != 'none':
 		taskset.add(initd.AdjustExpandRootScript)


### PR DESCRIPTION
To control whether ec2 init scripts should be installed
on the image. Defaults to true, to keep current behaviour.