### PR TITLE
EC2: Only install dhcpcd on releases before jessie

### DIFF
--- a/bootstrapvz/providers/ec2/tasks/packages.py
+++ b/bootstrapvz/providers/ec2/tasks/packages.py
@@ -9,15 +9,13 @@ class DefaultPackages(Task):
 	@classmethod
 	def run(cls, info):
 		info.packages.add('file')  # Needed for the init scripts
-		# isc-dhcp-client doesn't work properly with ec2
-		from bootstrapvz.common.releases import jessie
-		if info.manifest.release >= jessie:
-			info.packages.add('dhcpcd5')
-		else:
-			info.packages.add('dhcpcd')
 
-		info.exclude_packages.add('isc-dhcp-client')
-		info.exclude_packages.add('isc-dhcp-common')
+		# isc-dhcp-client before jessie doesn't work properly with ec2
+		from bootstrapvz.common.releases import jessie
+		if info.manifest.release < jessie:
+			info.packages.add('dhcpcd')
+			info.exclude_packages.add('isc-dhcp-client')
+			info.exclude_packages.add('isc-dhcp-common')
 
 		import os.path
 		kernel_packages_path = os.path.join(os.path.dirname(__file__), 'packages-kernels.yml')


### PR DESCRIPTION
Otherwise, keep Debian's default isc-dhcp-client, it works fine
on EC2.