### PR TITLE
Change the order we clean up the apt state for GCE images.

### DIFF
--- a/bootstrapvz/providers/gce/tasks/apt.py
+++ b/bootstrapvz/providers/gce/tasks/apt.py
@@ -40,7 +40,8 @@ class ImportGoogleKey(Task):
 class CleanGoogleRepositoriesAndKeys(Task):
 	description = 'Removing Google key and apt source files'
 	phase = phases.system_cleaning
-	successors = [apt.AptClean, network.RemoveDNSInfo]
+	predecessors = [apt.AptClean]
+	successors = [network.RemoveDNSInfo]
 
 	@classmethod
 	def run(cls, info):


### PR DESCRIPTION
The result is that we leave a set of apt list files current as of the image build on the resulting image instead of no cache whatsoever.