### PR TITLE
Fix expand-root script to work for Debian 8 and simplify how partition types are formulated.

### DIFF
--- a/bootstrapvz/common/assets/init.d/expand-root
+++ b/bootstrapvz/common/assets/init.d/expand-root
@@ -15,7 +15,7 @@ logger="logger -t $prog"
 
 device_path="/dev/xvda"
 
-filesystem=`blkid | grep $device_path | sed 's#\(.*\):.*TYPE="\(.*\)".*#\2#'`
+filesystem=$(blkid -s TYPE -o value ${device_path})
 
 case $filesystem in
 	xfs)  xfs_growfs / ;;


### PR DESCRIPTION
blkid output changed between wheezy and jessie breaking this script