### PR TITLE
Patch udev init script to fix ROOTDELAY boot issue

### DIFF
--- a/bootstrapvz/providers/azure/__init__.py
+++ b/bootstrapvz/providers/azure/__init__.py
@@ -2,6 +2,7 @@ from bootstrapvz.common import task_groups
 import tasks.packages
 import tasks.boot
 import tasks.image
+import tasks.udev
 from bootstrapvz.common.tasks import loopback
 from bootstrapvz.common.tasks import initd
 from bootstrapvz.common.tasks import ssh
@@ -15,7 +16,6 @@ def validate_manifest(data, validator, error):
 
 def resolve_tasks(taskset, manifest):
 	taskset.update(task_groups.get_standard_groups(manifest))
-
 	taskset.update([tasks.packages.DefaultPackages,
 	                loopback.AddRequiredCommands,
 	                loopback.Create,
@@ -25,6 +25,7 @@ def resolve_tasks(taskset, manifest):
 	                ssh.AddSSHKeyGeneration,
 	                tasks.packages.Waagent,
 	                tasks.boot.ConfigureGrub,
+	                tasks.udev.PatchUdev,
 	                tasks.image.ConvertToVhd,
 	                ])
 

--- a/bootstrapvz/providers/azure/assets/udev.diff
+++ b/bootstrapvz/providers/azure/assets/udev.diff
@@ -1,0 +1,16 @@
+diff --git a/debian/extra/initramfs-tools/scripts/init-top/udev b/debian/extra/initramfs-tools/scripts/init-top/udev
+index 687911f..87f1121 100755
+--- a/debian/extra/initramfs-tools/scripts/init-top/udev
++++ b/debian/extra/initramfs-tools/scripts/init-top/udev
+@@ -31,11 +31,5 @@ if [ -d /sys/bus/scsi ]; then
+ 	udevadm settle || true
+ fi
+ 
+-# If the rootdelay parameter has been set, we wait a bit for devices
+-# like usb/firewire disks to settle.
+-if [ "$ROOTDELAY" ]; then
+-	sleep $ROOTDELAY
+-fi
+-
+ # Leave udev running to process events that come in out-of-band (like USB
+ # connections)

--- a/bootstrapvz/providers/azure/tasks/__init__.py
+++ b/bootstrapvz/providers/azure/tasks/__init__.py
@@ -1,0 +1,3 @@
+import os.path
+
+assets = os.path.normpath(os.path.join(os.path.dirname(__file__), '../assets'))

--- a/bootstrapvz/providers/azure/tasks/udev.py
+++ b/bootstrapvz/providers/azure/tasks/udev.py
@@ -1,0 +1,19 @@
+from bootstrapvz.base import Task
+from bootstrapvz.common import phases
+from bootstrapvz.common.tasks import kernel
+import subprocess
+import os.path
+from . import assets
+
+
+class PatchUdev(Task):
+	description = 'Patch udev configuration to remove ROOTDELAY sleep'
+	phase = phases.system_modification
+	successors = [kernel.UpdateInitramfs]
+
+	@classmethod
+	def run(cls, info):
+		# c.f. http://anonscm.debian.org/cgit/pkg-systemd/systemd.git/commit/?id=61e055638cea
+		with open(os.path.join(assets, 'udev.diff')) as diff_file:
+			udev_dir = os.path.join(info.root, 'usr/share/initramfs-tools/scripts/init-top')
+			subprocess.call(['patch', '--no-backup-if-mismatch', '-p6', '-d' + udev_dir], stdin=diff_file)


### PR DESCRIPTION
Hello guys, I would like to add a step to fix a boot delay issue with Azure. The `udev` init script is causing a delay when used with the recommended boot settings in Azure. (you have a link to the issue in the comments)
Feedback appreciated about the approach I took (applying a diff file instead of packing the complete file) -- overkill?
Thanks!