### PR TITLE
Fix DKMS version error; add Jessie & Btrfs support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 Alex Adriaanse:
 	* Fix DKMS kernel version error
 	* Add support for Btrfs
+	* Add EC2 Jessie HVM manifest
 
 2015-05-08
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2015-06-29
+----------
+Alex Adriaanse:
+	* Fix DKMS kernel version error
+
 2015-05-08
 ----------
 Alexandre Derumier:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 ----------
 Alex Adriaanse:
 	* Fix DKMS kernel version error
+	* Add support for Btrfs
 
 2015-05-08
 ----------

--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -150,7 +150,7 @@ definitions:
     type: object
     properties:
       filesystem:
-        enum: [ext2, ext3, ext4, xfs]
+        enum: [ext2, ext3, ext4, xfs, btrfs]
       format_command:
         items: {type: string}
         minItems: 1

--- a/bootstrapvz/providers/ec2/tasks/network.py
+++ b/bootstrapvz/providers/ec2/tasks/network.py
@@ -64,4 +64,4 @@ AUTOINSTALL="yes"
 		for task in ['add', 'build', 'install']:
 			# Invoke DKMS task using specified kernel module (-m) and version (-v)
 			log_check_call(['chroot', info.root,
-			                'dkms', task, '-m', 'ixgbevf', '-v', version])
+			                'dkms', task, '-m', 'ixgbevf', '-v', version, '-k', info.kernel_version])

--- a/manifests/official/ec2/ebs-jessie-amd64-hvm.yml
+++ b/manifests/official/ec2/ebs-jessie-amd64-hvm.yml
@@ -1,0 +1,33 @@
+---
+provider:
+  name: ec2
+  virtualization: hvm
+  enhanced_networking: simple
+  # credentials:
+  #   access-key: AFAKEACCESSKEYFORAWS
+  #   secret-key: thes3cr3tkeyf0ryourawsaccount/FS4d8Qdva
+bootstrapper:
+  workspace: /target
+image:
+  name: debian-{system.release}-{system.architecture}-{provider.virtualization}-{%Y}-{%m}-{%d}-ebs
+  description: Debian {system.release} {system.architecture}
+system:
+  release: jessie
+  architecture: amd64
+  bootloader: extlinux
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+  backing: ebs
+  partitions:
+    type: none
+    root:
+      filesystem: ext4
+      size: 8GiB
+packages:
+  mirror: http://cloudfront.debian.net/debian
+plugins:
+  cloud_init:
+    metadata_sources: Ec2
+    username: admin


### PR DESCRIPTION
This PR makes the following three changes:
* Fix an error that is triggered when the kernel version installed into the image is different from the kernel version that's currently running. This happens when, for example, building a Debian Jessie image with Linux kernel 3.16.0-4-amd64 from within Ubuntu 14.04 running kernel 3.13.0-55-generic. Without this fix you'd get the following error:

```
Error! Your kernel headers for kernel 3.13.0-55-generic cannot be found.
Please install the linux-headers-3.13.0-55-generic package,
or use the --kernelsourcedir option to tell DKMS where it's located
Command 'chroot /target/ce7efc8d/root dkms build -m ixgbevf -v 2.16.1' returned non-zero exit status 1
Traceback (most recent call last):
  File "/home/ubuntu/bootstrap-vz/bootstrapvz/base/main.py", line 109, in run
    tasklist.run(info=bootstrap_info, dry_run=dry_run)
  File "/home/ubuntu/bootstrap-vz/bootstrapvz/base/tasklist.py", line 43, in run
    task.run(info)
  File "/home/ubuntu/bootstrap-vz/bootstrapvz/providers/ec2/tasks/network.py", line 67, in run
    'dkms', task, '-m', 'ixgbevf', '-v', version])
  File "/home/ubuntu/bootstrap-vz/bootstrapvz/common/tools.py", line 13, in log_check_call
    raise e
CalledProcessError: Command 'chroot /target/ce7efc8d/root dkms build -m ixgbevf -v 2.16.1' returned non-zero exit status 1
```

* Add support for creating Btrfs-based images.
* Add an official EC2/HVM manifest for Jessie.