### PR TITLE
GRUB_HIDDEN_TIMEOUT should be a numeric value.

### DIFF
--- a/bootstrapvz/common/tasks/grub.py
+++ b/bootstrapvz/common/tasks/grub.py
@@ -29,7 +29,8 @@ class ConfigureGrub(Task):
 		sed_i(grub_def, '^GRUB_CMDLINE_LINUX_DEFAULT="quiet"',
 		                'GRUB_CMDLINE_LINUX_DEFAULT="console=hvc0"')
 		sed_i(grub_def, '^GRUB_TIMEOUT=[0-9]+', 'GRUB_TIMEOUT=0\n'
-		                                        'GRUB_HIDDEN_TIMEOUT=true')
+		                                        'GRUB_HIDDEN_TIMEOUT=0\n'
+		                                        'GRUB_HIDDEN_TIMEOUT_QUIET=true')
 		sed_i(grub_def, '^#GRUB_DISABLE_RECOVERY="true"', 'GRUB_DISABLE_RECOVERY="true"')
 
 


### PR DESCRIPTION
This changes GRUB_HIDDEN_TIMEOUT to 0 from true and sets
GRUB_HIDDEN_TIMEOUT_QUIET to true.