### PR TITLE
Make generation of an image tarball a common task

### DIFF
--- a/bootstrapvz/base/bootstrapinfo.py
+++ b/bootstrapvz/base/bootstrapinfo.py
@@ -55,6 +55,13 @@ class BootstrapInformation(object):
 		# that hint at how a command may be made available.
 		self.host_dependencies = {}
 
+		# Dictionary to store information about the image, like its resulting name
+		image_name = self.__parse_image_name(self.manifest, self.manifest_vars)
+		self.image = {
+		    'filename': image_name + '.' + self.volume.extension,
+		    'name': image_name,
+		}
+
 		# Lists of startup scripts that should be installed and disabled
 		self.initd = {'install': {}, 'disable': []}
 
@@ -130,6 +137,12 @@ class BootstrapInformation(object):
 		state = filter_state(self.__dict__)
 		state['__class__'] = self.__module__ + '.' + self.__class__.__name__
 		return state
+
+	def __parse_image_name(self, manifest, manifest_vars):
+		image_name = manifest.image['name'].format(**manifest_vars)
+		# Ensure that we do not use disallowed characters in image name
+		image_name = image_name.lower().replace('.', '-').replace(' ', '-')
+		return image_name
 
 	def __setstate__(self, state):
 		for key in state:

--- a/bootstrapvz/common/tasks/image.py
+++ b/bootstrapvz/common/tasks/image.py
@@ -1,5 +1,7 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
+from bootstrapvz.common.tools import log_check_call
+import os
 
 
 class MoveImage(Task):
@@ -11,7 +13,6 @@ class MoveImage(Task):
 		image_name = info.manifest.image['name'].format(**info.manifest_vars)
 		filename = image_name + '.' + info.volume.extension
 
-		import os.path
 		destination = os.path.join(info.manifest.bootstrapper['workspace'], filename)
 		import shutil
 		shutil.move(info.volume.image_path, destination)
@@ -19,3 +20,32 @@ class MoveImage(Task):
 		import logging
 		log = logging.getLogger(__name__)
 		log.info('The volume image has been moved to ' + destination)
+
+
+class CreateImageTarball(Task):
+	description = 'Creating tarball with image'
+	phase = phases.image_registration
+	predecessors = [MoveImage]
+
+	@classmethod
+	def run(cls, info):
+		image_name = info.manifest.image['name'].format(**info.manifest_vars)
+		filename = image_name + '.' + info.volume.extension
+
+		# Ensure that we do not use disallowed characters in image name
+		image_name = image_name.lower()
+		image_name = image_name.replace('.', '-')
+		image_name = image_name.replace(' ', '-')
+
+		tarball_name = image_name + '.tar.gz'
+		tarball_path = os.path.join(info.manifest.bootstrapper['workspace'], tarball_name)
+
+		# Store image information so it can be referenced later
+		info.image = {
+		    'name': image_name,
+		    'tarball_name': tarball_name,
+		    'tarball_path': tarball_path,
+		}
+
+		log_check_call(['tar', '--sparse', '-C', info.manifest.bootstrapper['workspace'],
+		                '-caf', tarball_path, filename])

--- a/bootstrapvz/plugins/vagrant/tasks.py
+++ b/bootstrapvz/plugins/vagrant/tasks.py
@@ -13,8 +13,7 @@ class CheckBoxPath(Task):
 
 	@classmethod
 	def run(cls, info):
-		box_basename = info.manifest.image['name'].format(**info.manifest_vars)
-		box_name = box_basename + '.box'
+		box_name = info.image['name'] + '.box'
 		box_path = os.path.join(info.manifest.bootstrapper['workspace'], box_name)
 		if os.path.exists(box_path):
 			from bootstrapvz.common.exceptions import TaskError

--- a/bootstrapvz/providers/ec2/tasks/ami.py
+++ b/bootstrapvz/providers/ec2/tasks/ami.py
@@ -18,7 +18,7 @@ class AMIName(Task):
 
 	@classmethod
 	def run(cls, info):
-		ami_name = info.manifest.image['name'].format(**info.manifest_vars)
+		ami_name = info.image['name']
 		ami_description = info.manifest.image['description'].format(**info.manifest_vars)
 
 		images = info._ec2['connection'].get_all_images(owners=['self'])

--- a/bootstrapvz/providers/gce/__init__.py
+++ b/bootstrapvz/providers/gce/__init__.py
@@ -49,7 +49,7 @@ def resolve_tasks(taskset, manifest):
 	                tasks.apt.CleanGoogleRepositoriesAndKeys,
 
 	                image.MoveImage,
-	                tasks.image.CreateTarball,
+	                image.CreateImageTarball,
 	                volume.Delete,
 	                ])
 

--- a/bootstrapvz/providers/gce/__init__.py
+++ b/bootstrapvz/providers/gce/__init__.py
@@ -48,6 +48,7 @@ def resolve_tasks(taskset, manifest):
 	                ssh.DisableSSHPasswordAuthentication,
 	                tasks.apt.CleanGoogleRepositoriesAndKeys,
 
+	                tasks.image.GenerateImageTarballName,
 	                image.MoveImage,
 	                image.CreateImageTarball,
 	                volume.Delete,

--- a/bootstrapvz/providers/gce/tasks/image.py
+++ b/bootstrapvz/providers/gce/tasks/image.py
@@ -2,47 +2,17 @@ from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import image
 from bootstrapvz.common.tools import log_check_call
-import os.path
-
-
-class CreateTarball(Task):
-	description = 'Creating tarball with image'
-	phase = phases.image_registration
-	predecessors = [image.MoveImage]
-
-	@classmethod
-	def run(cls, info):
-		import datetime
-		image_name = info.manifest.image['name'].format(**info.manifest_vars)
-		filename = image_name + '.' + info.volume.extension
-		today = datetime.datetime.today()
-		name_suffix = today.strftime('%Y%m%d')
-		image_name_format = '{lsb_distribution}-{lsb_release}-{release}-v{name_suffix}'
-		image_name = image_name_format.format(lsb_distribution=info._gce['lsb_distribution'],
-		                                      lsb_release=info._gce['lsb_release'],
-		                                      release=info.manifest.system['release'],
-		                                      name_suffix=name_suffix)
-		# ensure that we do not use disallowed characters in image name
-		image_name = image_name.lower()
-		image_name = image_name.replace(".", "-")
-		info._gce['image_name'] = image_name
-		tarball_name = image_name + '.tar.gz'
-		tarball_path = os.path.join(info.manifest.bootstrapper['workspace'], tarball_name)
-		info._gce['tarball_name'] = tarball_name
-		info._gce['tarball_path'] = tarball_path
-		log_check_call(['tar', '--sparse', '-C', info.manifest.bootstrapper['workspace'],
-		                '-caf', tarball_path, filename])
 
 
 class UploadImage(Task):
 	description = 'Uploading image to GCS'
 	phase = phases.image_registration
-	predecessors = [CreateTarball]
+	predecessors = [image.CreateImageTarball]
 
 	@classmethod
 	def run(cls, info):
-		log_check_call(['gsutil', 'cp', info._gce['tarball_path'],
-		                info.manifest.image['gcs_destination'] + info._gce['tarball_name']])
+		log_check_call(['gsutil', 'cp', info.image['tarball_path'],
+		                info.manifest.image['gcs_destination'] + info.image['tarball_name']])
 
 
 class RegisterImage(Task):
@@ -56,6 +26,6 @@ class RegisterImage(Task):
 		if 'description' in info.manifest.image:
 			image_description = info.manifest.image['description']
 		log_check_call(['gcutil', '--project=' + info.manifest.image['gce_project'],
-		                'addimage', info._gce['image_name'],
-		                info.manifest.image['gcs_destination'] + info._gce['tarball_name'],
+		                'addimage', info.image['name'],
+		                info.manifest.image['gcs_destination'] + info.image['tarball_name'],
 		                '--description=' + image_description])


### PR DESCRIPTION
@andsens there are a couple things here which I would like to ask for your opinion. :-)

[Changes 'MoveImage' from `loopback` to `image`][1]

Moved `MoveImage` from the `loopback` common module a new one named `image`. Does that sounds reasonable to you? To me, it makes more sense if it grouped with tasks regarding images, not exactly loopback volumes.

[Make generation of an image tarball a common task][2]

I've created a common task to generate a compressed tarball of the image file, heavily based on a GCE task which did exactly this. Two problems appeared with this approach:

* What is the proper way to add a new attribute to the `info` object? I've tried to [create a new dict][3], but if anyone wants to add some other parameters to it on another task, they might be overwritten. This is defined using a [simple variable attribution][4] at some places, but this looks like to work only with attributes which their name starts with underscore. Possibly, there are attributes like this being generated for every provider, e.g. `gce` has a `info._gce`?
* The [image tarball name generation for GCE][5] is a little bit complex. At first, I thought that was just a matter of defining the name on the manifest itself, but this isn't possible. GCE is using [a specific task][6] to gather information about the Debian version that is being bootstrapped, then using this data to generate the image tarball name. I've though about creating an intermediary task which defines the image name (is it possible to have a generic one, then overriding it when needed for a specific to the provider? Or do we have to manually discard the generic and add the specific to the tasklist?), and then checking if the name was already defined (and stored on the `info` object). Do you see a simpler way to do this?
* This is probably more suited to be answered by @wrigri or @zmarano: does the RAW image file, stored on the compressed image tarball **should** be named `disk.raw` on GCE?

[1]: https://github.com/andsens/bootstrap-vz/commit/69c5f2fbec854fb9a4e038bf31351a23a16c0ab9
[2]: https://github.com/andsens/bootstrap-vz/commit/0b5a0737d4d0068acc47ffb4fedfe1aaf58db152
[3]: https://github.com/andsens/bootstrap-vz/commit/0b5a0737d4d0068acc47ffb4fedfe1aaf58db152#diff-c6be75ec30df38d0db25e863bcbba1daR44
[4]: https://github.com/andsens/bootstrap-vz/blob/0068cdc1a8a15061856a962045984126476b9583/bootstrapvz/providers/gce/tasks/image.py#L28
[5]: https://github.com/andsens/bootstrap-vz/blob/0068cdc1a8a15061856a962045984126476b9583/bootstrapvz/providers/gce/tasks/image.py#L20
[6]: https://github.com/andsens/bootstrap-vz/blob/0068cdc1a8a15061856a962045984126476b9583/bootstrapvz/providers/gce/tasks/configuration.py#L6