### PR TITLE
ignore loopback interface in udev rules

### DIFF
--- a/bootstrapvz/providers/ec2/assets/ec2/ec2net-functions
+++ b/bootstrapvz/providers/ec2/assets/ec2/ec2net-functions
@@ -85,7 +85,7 @@ get_secondary_ipv4s() {
 }
 
 remove_primary() {
-  if [ "${INTERFACE}" == "eth0" ]; then
+  if [ "${INTERFACE}" == "eth0" -o "${INTERFACE}" == "lo" ]; then
     return
   fi
   rm -f ${config_file}
@@ -94,7 +94,7 @@ remove_primary() {
 }
 
 rewrite_primary() {
-  if [ "${INTERFACE}" == "eth0" ]; then
+  if [ "${INTERFACE}" == "eth0" -o "${INTERFACE}" == "lo" ]; then
     return
   fi
   cidr=$(get_cidr)


### PR DESCRIPTION
I was investigating issue with 30 second delay during boot time and found that it happens in a `networking` service:
```
systemd-analyze  blame 
         30.188s networking.service
```

after some debugging I added one more exclusion for loopback interface and it takes 10 times less now:
```
 systemd-analyze  blame 
          3.078s networking.service
```