### PR TITLE
enable support for creating kvm images for jessie on arm64

### DIFF
--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -42,7 +42,7 @@ properties:
     type: object
     properties:
       architecture:
-        enum: [i386, amd64]
+        enum: [i386, amd64, arm64]
       userspace_architecture:
         enum: [i386]
       bootloader:

--- a/bootstrapvz/providers/kvm/manifest-schema.yml
+++ b/bootstrapvz/providers/kvm/manifest-schema.yml
@@ -26,6 +26,7 @@ properties:
         enum:
         - grub
         - extlinux
+        - none
   volume:
     type: object
     properties:

--- a/bootstrapvz/providers/kvm/tasks/packages-kernels.yml
+++ b/bootstrapvz/providers/kvm/tasks/packages-kernels.yml
@@ -9,6 +9,7 @@ wheezy:
 jessie:
   amd64: linux-image-amd64
   i386: linux-image-686-pae
+  arm64: linux-image-arm64
 sid:
   amd64: linux-image-amd64
   i386: linux-image-686-pae

--- a/manifests/examples/kvm/jessie-arm64-virtio.yml
+++ b/manifests/examples/kvm/jessie-arm64-virtio.yml
@@ -1,0 +1,32 @@
+---
+name: debian-{system.release}-{system.architecture}-{%y}{%m}{%d}
+provider:
+  name: kvm
+  virtio_modules:
+  - virtio_pci
+  - virtio_blk
+bootstrapper:
+  workspace: /target
+system:
+  release: jessie
+  architecture: arm64
+  bootloader: none
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+  backing: raw
+  partitions:
+    type: msdos
+    boot:
+      filesystem: ext2
+      size: 32MiB
+    root:
+      filesystem: ext4
+      size: 864MiB
+    swap:
+      size: 128MiB
+packages: {}
+plugins:
+  root_password:
+    password: test


### PR DESCRIPTION
These minor changes allow bootstrap-vz to build a kvm image for jessie on arm64, by updating the schema to accept arm64 as an architecture, no bootloader, and providing an example manifest.