### PR TITLE
euca2ools requires libxslt which requires zlibg1-dev to build via pip.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ must install it directly from the eucalyptus repository like this:
 
 .. code:: sh
 
-    apt-get install --no-install-recommends python-dev libxml2-dev libxslt-dev gcc
+    apt-get install --no-install-recommends python-dev libxml2-dev libxslt-dev gcc zlib1g-dev
     pip install git+git://github.com/eucalyptus/euca2ools.git@v3.2.0
 
 Cleanup


### PR DESCRIPTION
Hi, seems like euca2ools has a missing dependency. Please let me know if you could merge this. Thanks!