### PR TITLE
[set localtime]: Set /etc/localtime by either copying or symlinking

### DIFF
--- a/bootstrapvz/common/task_groups.py
+++ b/bootstrapvz/common/task_groups.py
@@ -33,16 +33,7 @@ def get_standard_groups(manifest):
 	group.extend(get_network_group(manifest))
 	group.extend(get_apt_group(manifest))
 	group.extend(security_group)
-
-	from bootstrapvz.common.releases import jessie
-	if manifest.release > jessie:
-		if not locale.SetLocalTimeLink in locale_group:
-			locale_group.extend(locale.SetLocalTimeLink)
-	else:
-		if not locale.SetLocalTimeCopy in locale_group:
-			locale_group.extend(locale.SetLocalTimeCopy)
-	group.extend(locale_group)
-
+	group.extend(get_locale_group(manifest))
 	group.extend(get_bootloader_group(manifest))
 	group.extend(cleanup_group)
 	return group
@@ -142,10 +133,19 @@ def get_apt_group(manifest):
 
 security_group = [security.EnableShadowConfig]
 
-locale_group = [locale.LocaleBootstrapPackage,
-                locale.GenerateLocale,
-                locale.SetTimezone,
-                ]
+
+def get_locale_group(manifest):
+	from bootstrapvz.common.releases import jessie
+	group = [
+		locale.LocaleBootstrapPackage,
+		locale.GenerateLocale,
+		locale.SetTimezone,
+	]
+	if manifest.release > jessie:
+		group.append(locale.SetLocalTimeLink)
+	else:
+		group.append(locale.SetLocalTimeCopy)
+	return group
 
 
 def get_bootloader_group(manifest):

--- a/bootstrapvz/common/task_groups.py
+++ b/bootstrapvz/common/task_groups.py
@@ -33,7 +33,16 @@ def get_standard_groups(manifest):
 	group.extend(get_network_group(manifest))
 	group.extend(get_apt_group(manifest))
 	group.extend(security_group)
+
+	from bootstrapvz.common.releases import jessie
+	if manifest.release > jessie:
+		if not locale.SetLocalTimeLink in locale_group:
+			locale_group.extend(locale.SetLocalTimeLink)
+	else:
+		if not locale.SetLocalTimeCopy in locale_group:
+			locale_group.extend(locale.SetLocalTimeCopy)
 	group.extend(locale_group)
+
 	group.extend(get_bootloader_group(manifest))
 	group.extend(cleanup_group)
 	return group

--- a/bootstrapvz/common/tasks/locale.py
+++ b/bootstrapvz/common/tasks/locale.py
@@ -43,11 +43,32 @@ class SetTimezone(Task):
 
 	@classmethod
 	def run(cls, info):
-		from shutil import copy
 		tz_path = os.path.join(info.root, 'etc/timezone')
 		timezone = info.manifest.system['timezone']
 		with open(tz_path, 'w') as tz_file:
 			tz_file.write(timezone)
+
+
+class SetLocalTimeLink(Task):
+	description = 'Setting the selected local timezone (link)'
+	phase = phases.system_modification
+
+	@classmethod
+	def run(cls, info):
+		timezone = info.manifest.system['timezone']
+		localtime_path = os.path.join(info.root, 'etc/localtime')
+		os.unlink(localtime_path)
+		os.symlink(os.path.join('/usr/share/zoneinfo', timezone), localtime_path)
+
+
+class SetLocalTimeCopy(Task):
+	description = 'Setting the selected local timezone (copy)'
+	phase = phases.system_modification
+
+	@classmethod
+	def run(cls, info):
+		from shutil import copy
+		timezone = info.manifest.system['timezone']
 		zoneinfo_path = os.path.join(info.root, '/usr/share/zoneinfo', timezone)
 		localtime_path = os.path.join(info.root, 'etc/localtime')
 		copy(zoneinfo_path, localtime_path)


### PR DESCRIPTION
Starting in version 2016a-1 (circa Jan 2016) the package tzdata
changed /etc/timezone into a symlink. This change is in unstable,
testing, and will be in the next release (stretch). This commit checks
the release, and creates a task to either copy the contents of the
zoneinfo file (jessie and older) or create a symbolic link (newer than
jessie).

Signed-off-by: Manoj Srivastava <srivasta@golden-gryphon.com>