### PR TITLE
nbd kernel module isn't loaded by default. This specifically doesn't …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,7 @@ VirtualBox Vagrant
 .. code:: sh
 
     user@host:~$ sudo -i # become root
+    root@host:~# modprobe nbd max_part=3
     root@host:~# git clone https://github.com/andsens/bootstrap-vz.git # Clone the repo
     root@host:~# apt-get install qemu-utils debootstrap python-pip # Install dependencies from aptitude
     root@host:~# pip install termcolor jsonschema fysom docopt pyyaml # Install python dependencies


### PR DESCRIPTION
…work

when building a vagrant box using the debian/jessie64 vagrant box from
Atlas.

The kernel module `nbd' must be loaded (run `modprobe nbd max_part=3') to attach .vmdk images
Traceback (most recent call last):
  File "/vagrant/bootstrap-vz/bootstrapvz/base/main.py", line 109, in run
    tasklist.run(info=bootstrap_info, dry_run=dry_run)
  File "/vagrant/bootstrap-vz/bootstrapvz/base/tasklist.py", line 43, in run
    task.run(info)
  File "/vagrant/bootstrap-vz/bootstrapvz/common/tasks/volume.py", line 12, in run
    info.volume.attach()
  File "/vagrant/bootstrap-vz/bootstrapvz/common/fsm_proxy.py", line 39, in proxy
    fn(**kwargs)
  File "/usr/local/lib/python2.7/dist-packages/fysom/__init__.py", line 283, in fn
    if self._before_event(e) is False:
  File "/usr/local/lib/python2.7/dist-packages/fysom/__init__.py", line 318, in _before_event
    return getattr(self, fnname)(e)
  File "/usr/local/lib/python2.7/dist-packages/fysom/__init__.py", line 89, in _callback
    return func(obj, *args, **kwargs)
  File "/vagrant/bootstrap-vz/bootstrapvz/common/fs/qemuvolume.py", line 42, in _before_attach
    self._check_nbd_module()
  File "/vagrant/bootstrap-vz/bootstrapvz/common/fs/qemuvolume.py", line 29, in _check_nbd_module
    raise VolumeError(msg)
VolumeError: The kernel module `nbd' must be loaded (run `modprobe nbd max_part=3') to attach .vmdk images
Rolling back