### PR TITLE
Add a debconf plugin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2016-02-23
+----------
+Nicolas Braud-Santoni:
+	* #282, #290: Added 'debconf' plugin
+	* #290: Relaxed requirements on plugins manifests
+
 2016-02-10
 ----------
 Manoj Srivastava:

--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -121,7 +121,8 @@ properties:
   plugins:
     type: object
     patternProperties:
-      ^\w+$: {type: object}
+      ^\w+$: {}
+    additionalProperties: false
   volume:
     type: object
     properties:

--- a/bootstrapvz/plugins/debconf/README.rst
+++ b/bootstrapvz/plugins/debconf/README.rst
@@ -1,0 +1,24 @@
+debconf
+-------
+
+``debconf(7)`` is the configuration system for Debian packages.
+It enables you to preconfigure packages before their installation.
+
+This plugin lets you specify debconf answers directly in the manifest.
+You should only specify answers for packages that will be installed; the plugin
+does not check that this is the case.
+
+Settings
+~~~~~~~~
+
+The ``debconf`` plugin directly takes an inline string:::
+
+  plugins:
+    debconf: >-
+      d-i pkgsel/install-language-support boolean false
+      popularity-contest popularity-contest/participate boolean false
+
+
+Consult ``debconf-set-selections(1)`` for a description of the data format.
+
+

--- a/bootstrapvz/plugins/debconf/__init__.py
+++ b/bootstrapvz/plugins/debconf/__init__.py
@@ -1,0 +1,13 @@
+def validate_manifest(data, validator, error):
+    from bootstrapvz.common.tools import log_check_call
+    import os.path
+    schema_path = os.path.join(os.path.dirname(__file__),
+                               'schema.yaml')
+    validator(data, schema_path)
+    log_check_call(['debconf-set-selections', '--checkonly'],
+                   stdin=data['plugins']['debconf'])
+
+
+def resolve_tasks(taskset, manifest):
+    import tasks
+    taskset.update([tasks.DebconfSetSelections])

--- a/bootstrapvz/plugins/debconf/schema.yaml
+++ b/bootstrapvz/plugins/debconf/schema.yaml
@@ -1,0 +1,14 @@
+$schema: http://json-schema.org/schema#
+title: Manifest schema for the debconf plugin
+type: object
+properties:
+  plugins:
+    type: object
+    properties:
+      debconf:
+        name: Debconf selections to set
+        description: >-
+          This value should be an inline string in the
+          input format of debconf-set-selections(1).
+        type: string
+    required: [debconf]

--- a/bootstrapvz/plugins/debconf/tasks.py
+++ b/bootstrapvz/plugins/debconf/tasks.py
@@ -1,0 +1,15 @@
+from bootstrapvz.base import Task
+from bootstrapvz.common import phases
+from bootstrapvz.common.tasks import packages
+from bootstrapvz.common.tools import log_check_call
+
+
+class DebconfSetSelections(Task):
+    description = 'Set debconf(7) selections from the manifest'
+    phase = phases.package_installation
+    successors = [packages.InstallPackages]
+
+    @classmethod
+    def run(cls, info):
+        log_check_call(['chroot', info.root, 'debconf-set-selections'],
+                       stdin=info.manifest.plugins['debconf'])


### PR DESCRIPTION
This is my take on #282.

This lets you set debconf answers before extra packages are installed (but after the OS setup).