### PR TITLE
admin_user plugin: Fix non-EC2 behaviour

### DIFF
--- a/bootstrapvz/plugins/admin_user/__init__.py
+++ b/bootstrapvz/plugins/admin_user/__init__.py
@@ -23,7 +23,7 @@ def resolve_tasks(taskset, manifest):
 		taskset.add(tasks.AdminUserPassword)
 	if 'pubkey' in manifest.plugins['admin_user']:
 		taskset.add(tasks.AdminUserPublicKey)
-	else:
+	elif manifest.provider['name'] == 'ec2':
 		taskset.add(tasks.AdminUserPublicKeyEC2)
 
 	taskset.update([tasks.AddSudoPackage,

--- a/bootstrapvz/plugins/admin_user/__init__.py
+++ b/bootstrapvz/plugins/admin_user/__init__.py
@@ -11,6 +11,7 @@ def validate_manifest(data, validator, error):
 
 
 def resolve_tasks(taskset, manifest):
+        import logging
 	import tasks
 	from bootstrapvz.common.tasks import ssh
 
@@ -21,10 +22,14 @@ def resolve_tasks(taskset, manifest):
 	if 'password' in manifest.plugins['admin_user']:
 		taskset.discard(ssh.DisableSSHPasswordAuthentication)
 		taskset.add(tasks.AdminUserPassword)
+
 	if 'pubkey' in manifest.plugins['admin_user']:
 		taskset.add(tasks.AdminUserPublicKey)
 	elif manifest.provider['name'] == 'ec2':
+		logging.getLogger(__name__).info("The SSH key will be obtained from EC2")
 		taskset.add(tasks.AdminUserPublicKeyEC2)
+	elif 'password' not in manifest.plugins['admin_user']:
+		logging.getLogger(__name__).warn("No SSH key and no password set")
 
 	taskset.update([tasks.AddSudoPackage,
 	                tasks.CreateAdminUser,


### PR DESCRIPTION
Currently, `admin_user` attempts to add the task `AdminUserPublicKeyEC2` if no pubkey is specified, which results in an error if the provider is not EC2.

This patch introduces an additional check, and simply sets no public key if none is defined and the provider is not EC2.