### PR TITLE
Cleanup package list and add in other packages

### DIFF
--- a/bootstrapvz/providers/gce/tasks/packages-kernels.yml
+++ b/bootstrapvz/providers/gce/tasks/packages-kernels.yml
@@ -1,14 +1,10 @@
 ---
 # This is a mapping of Debian release codenames to processor architectures to kernel packages
-squeeze: # In squeeze, we need a special kernel flavor for xen
-  amd64: linux-image-xen-amd64
-  i386: linux-image-xen-686
 wheezy:
   amd64: linux-image-amd64
-  i386: linux-image-686
 jessie:
   amd64: linux-image-amd64
-  i386: linux-image-686-pae
+stretch:
+  amd64: linux-image-amd64
 sid:
   amd64: linux-image-amd64
-  i386: linux-image-686-pae

--- a/bootstrapvz/providers/gce/tasks/packages.py
+++ b/bootstrapvz/providers/gce/tasks/packages.py
@@ -14,15 +14,24 @@ class DefaultPackages(Task):
 
 	@classmethod
 	def run(cls, info):
-		info.packages.add('python')
-		info.packages.add('sudo')
-		info.packages.add('ntp')
-		info.packages.add('lsb-release')
 		info.packages.add('acpi-support-base')
+		info.packages.add('ca-certificates')
+		info.packages.add('curl')
+		info.packages.add('ethtool')
+		info.packages.add('gdisk')
+		info.packages.add('kpartx')
+		info.packages.add('isc-dhcp-client')
+		info.packages.add('lsb-release')
+		info.packages.add('ntp')
+		info.packages.add('parted')
+		info.packages.add('python')
 		info.packages.add('openssh-client')
 		info.packages.add('openssh-server')
-		info.packages.add('dhcpd')
-		info.packages.add('ca-certificates')
+		info.packages.add('rsync')
+		info.packages.add('screen')
+		info.packages.add('sudo')
+		info.packages.add('uuid-runtime')
+		info.packages.add('vim')
 
 		kernel_packages_path = os.path.join(os.path.dirname(__file__), 'packages-kernels.yml')
 		kernel_package = config_get(kernel_packages_path, [info.manifest.release.codename,

--- a/bootstrapvz/providers/gce/tasks/packages.py
+++ b/bootstrapvz/providers/gce/tasks/packages.py
@@ -27,11 +27,8 @@ class DefaultPackages(Task):
 		info.packages.add('python')
 		info.packages.add('openssh-client')
 		info.packages.add('openssh-server')
-		info.packages.add('rsync')
-		info.packages.add('screen')
 		info.packages.add('sudo')
 		info.packages.add('uuid-runtime')
-		info.packages.add('vim')
 
 		kernel_packages_path = os.path.join(os.path.dirname(__file__), 'packages-kernels.yml')
 		kernel_package = config_get(kernel_packages_path, [info.manifest.release.codename,

--- a/manifests/official/gce/jessie-backports.yml
+++ b/manifests/official/gce/jessie-backports.yml
@@ -19,7 +19,11 @@ volume:
     root:
       filesystem: ext4
       size: 10GiB
-packages: {}
+packages:
+  install:
+    - rsync
+    - screen
+    - vim
 plugins:
   google_cloud_sdk: {}
   ntp:

--- a/manifests/official/gce/jessie.yml
+++ b/manifests/official/gce/jessie.yml
@@ -19,7 +19,11 @@ volume:
     root:
       filesystem: ext4
       size: 10GiB
-packages: {}
+packages:
+  install:
+    - rsync
+    - screen
+    - vim
 plugins:
   google_cloud_sdk: {}
   ntp:

--- a/manifests/official/gce/wheezy-backports.yml
+++ b/manifests/official/gce/wheezy-backports.yml
@@ -20,6 +20,10 @@ volume:
       filesystem: ext4
       size: 10GiB
 packages:
+  install:
+    - rsync
+    - screen
+    - vim
   preferences:
     backport-kernel:
     - package: linux-image-* initramfs-tools

--- a/manifests/official/gce/wheezy.yml
+++ b/manifests/official/gce/wheezy.yml
@@ -19,7 +19,11 @@ volume:
     root:
       filesystem: ext4
       size: 10GiB
-packages: {}
+packages:
+  install:
+    - rsync
+    - screen
+    - vim
 plugins:
   google_cloud_sdk: {}
   ntp:


### PR DESCRIPTION
These packages were being added outside of bootstrap-vz by our build scripts.
Remove i386 kernels that GCE does not support as well as squeeze (never supported), and add in a stretch kernel.