### PR TITLE
file_copy: Fix manifest and document

### DIFF
--- a/bootstrapvz/plugins/file_copy/README.rst
+++ b/bootstrapvz/plugins/file_copy/README.rst
@@ -1,0 +1,26 @@
+File copy
+---------
+
+This plugin lets you copy files from the host to the VM under construction,
+  create directories, and set permissions and ownership.
+
+Note that this necessarily violates the `first development guideline`_.
+
+.. _first development guideline: https://github.com/andsens/bootstrap-vz/blob/master/CONTRIBUTING.rst#the-manifest-should-always-fully-describe-the-resulting-image
+
+
+Settings
+~~~~~~~~
+
+The ``file_copy`` plugin takes a (non-empty) ``files`` list, and optionnaly a ``mkdirs`` list.
+
+Files (items in the ``files`` list) must be objects with the following properties:
+* ``src`` and ``dst`` (required) are the source and destination paths.
+  ``src`` is relative to the current directory, whereas ``dst`` is a path in the VM.
+* ``permissions`` (optional) is a permission string in a format appropriate for ``chmod(1)``.
+* ``owner`` and ``group`` (optional) are respectively a user and group specification,
+  in a format appropriate for ``chown(1)`` and ``chgrp(1)``.
+
+Folders (items in the ``mkdirs`` list) must be objects with the following properties:
+* ``dir`` (required) is the path of the directory.
+* ``permissions``, ``owner`` and ``group`` are the same as for files.

--- a/bootstrapvz/plugins/file_copy/__init__.py
+++ b/bootstrapvz/plugins/file_copy/__init__.py
@@ -3,13 +3,18 @@ import tasks
 
 def validate_manifest(data, validator, error):
 	import os.path
+
 	schema_path = os.path.normpath(os.path.join(os.path.dirname(__file__), 'manifest-schema.yml'))
 	validator(data, schema_path)
 
+	for i, file_entry in enumerate(data['plugins']['file_copy']['files']):
+		srcfile = file_entry['src']
+		if not os.path.isfile(srcfile):
+			msg = 'The source file %s does not exist.' % srcfile
+			error(msg, ['plugins', 'file_copy', 'files', i])
+
 
 def resolve_tasks(taskset, manifest):
-	taskset.add(tasks.ValidateSourcePaths)
-
 	if ('mkdirs' in manifest.plugins['file_copy']):
 		taskset.add(tasks.MkdirCommand)
 	if ('files' in manifest.plugins['file_copy']):

--- a/bootstrapvz/plugins/file_copy/manifest-schema.yml
+++ b/bootstrapvz/plugins/file_copy/manifest-schema.yml
@@ -7,31 +7,38 @@ properties:
         properties:
           mkdirs:
             items:
-              dir:
-                $ref: '#/definitions/absolute_path'
-              permissions:
-                type: string
-              owner:
-                type: string
-              group:
-                type: string
+              type: object
+              properties:
+                dir:
+                  type: string
+                permissions:
+                  type: string
+                owner:
+                  type: string
+                group:
+                  type: string
+              required: [dir]
+              additionalProperties: false
+
           files:
-            items:
-              src:
-                $ref: '#/definitions/absolute_path'
-              dst:
-                $ref: '#/definitions/absolute_path'
-              permissions:
-                type: string
-              owner:
-                type: string
-              group:
-                type: string
-            minItems: 1
             type: array
-            required:
-              - src
-              - dst
+            minItems: 1
+            items:
+              type: object
+              properties:
+                src:
+                  type: string
+                dst:
+                  type: string
+                permissions:
+                  type: string
+                owner:
+                  type: string
+                group:
+                  type: string
+              required: [src, dst]
+              additionalProperties: false
+
         required:
         - files
         type: object

--- a/bootstrapvz/plugins/file_copy/tasks.py
+++ b/bootstrapvz/plugins/file_copy/tasks.py
@@ -5,20 +5,6 @@ import os
 import shutil
 
 
-class ValidateSourcePaths(Task):
-	description = 'Check whether the files to be copied exist'
-	phase = phases.preparation
-
-	@classmethod
-	def run(cls, info):
-		from bootstrapvz.common.exceptions import TaskError
-		for file_entry in info.manifest.plugins['file_copy']['files']:
-			srcfile = file_entry['src']
-			if not os.path.isfile(srcfile):
-				msg = 'The source file %s does not exist.' % srcfile
-				raise TaskError(msg)
-
-
 def modify_path(info, path, entry):
 	from bootstrapvz.common.tools import log_check_call
 	if 'permissions' in entry:


### PR DESCRIPTION
The manifest for the `file_copy` plugin was failing to validate the data properly.