### PR TITLE
Again fix the expand-root script for GCE.

### DIFF
--- a/bootstrapvz/providers/gce/__init__.py
+++ b/bootstrapvz/providers/gce/__init__.py
@@ -40,6 +40,7 @@ def resolve_tasks(taskset, manifest):
 	                tasks.host.InstallHostnameHook,
 	                tasks.boot.ConfigureGrub,
 	                initd.AddExpandRoot,
+	                tasks.initd.AdjustExpandRootDev,
 	                initd.InstallInitScripts,
 	                boot.BlackListModules,
 	                boot.UpdateInitramfs,

--- a/bootstrapvz/providers/gce/tasks/initd.py
+++ b/bootstrapvz/providers/gce/tasks/initd.py
@@ -28,7 +28,7 @@ class AddGrowRootDisable(Task):
 
 class AdjustExpandRootDev(Task):
 	description = 'Adjusting the expand-root device'
-	phase = phases.system_modificatio
+	phase = phases.system_modification
 	predecessors = [initd.AddExpandRoot, initd.AdjustExpandRootScript]
 
 	@classmethod

--- a/bootstrapvz/providers/gce/tasks/initd.py
+++ b/bootstrapvz/providers/gce/tasks/initd.py
@@ -1,6 +1,7 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import kernel
+from bootstrapvz.common.tasks import initd
 from . import assets
 import os.path
 

--- a/bootstrapvz/providers/gce/tasks/initd.py
+++ b/bootstrapvz/providers/gce/tasks/initd.py
@@ -23,3 +23,15 @@ class AddGrowRootDisable(Task):
                             'etc/initramfs-tools/scripts/local-premount/gce-disable-growroot')
 		copy(script_src, script_dst)
 		os.chmod(script_dst, rwxr_xr_x)
+
+
+class AdjustExpandRootDev(Task):
+	description = 'Adjusting the expand-root device'
+	phase = phases.system_modificatio
+	predecessors = [initd.AddExpandRoot, initd.AdjustExpandRootScript]
+
+	@classmethod
+	def run(cls, info):
+		from bootstrapvz.common.tools import sed_i
+		script = os.path.join(info.root, 'etc/init.d/expand-root')
+		sed_i(script, '/dev/loop0', '/dev/sda')


### PR DESCRIPTION
The volume is not /dev/loop0 but it should be /dev/sda.

Outside the scope of fixing my immediate problem here, should there be something in the manifest for volume to denote the resulting image's device_path instead of the install device_path (which will change depending upon what kind of volume you are using). If you agree, I'll create an issue for that because it seems like something you should be able to specify in a manifest file.