### PR TITLE
fix document toctree

### DIFF
--- a/bootstrapvz/providers/gce/README.rst
+++ b/bootstrapvz/providers/gce/README.rst
@@ -1,5 +1,5 @@
 Google Compute Engine
----------------------
+=====================
 
 The `GCE <https://cloud.google.com/products/compute-engine/>`__ provider
 can creates image as expected by GCE - i.e. raw disk image in \*.tar.gz

--- a/bootstrapvz/providers/kvm/README.rst
+++ b/bootstrapvz/providers/kvm/README.rst
@@ -1,5 +1,5 @@
 KVM
----
+===
 
 The `KVM <http://www.linux-kvm.org/page/Main_Page>`__ provider creates
 virtual images for Linux Kernel-based Virtual Machines. It supports the

--- a/bootstrapvz/providers/virtualbox/README.rst
+++ b/bootstrapvz/providers/virtualbox/README.rst
@@ -1,5 +1,5 @@
 VirtualBox
-----------
+==========
 
 The `VirtualBox <https://www.virtualbox.org/>`__ provider can bootstrap
 to both .vdi and .vmdk images (raw images are also supported but do not


### PR DESCRIPTION
Fix invalid item levels.
All manifest settings should be same toctree level like following.

- EC2
  - Manifest settings
- Google Compute Engine
  - Manifest settings
- KVM
  - Manifest settings
