### PR TITLE
Do not remove ::1 from the loopback interface.

### DIFF
--- a/bootstrapvz/providers/gce/tasks/host.py
+++ b/bootstrapvz/providers/gce/tasks/host.py
@@ -15,6 +15,7 @@ class DisableIPv6(Task):
 		network_configuration_path = os.path.join(info.root, 'etc/sysctl.d/70-disable-ipv6.conf')
 		with open(network_configuration_path, 'w') as config_file:
 			print >>config_file, "net.ipv6.conf.all.disable_ipv6 = 1"
+			print >>config_file, "net.ipv6.conf.lo.disable_ipv6 = 0"
 
 
 class InstallHostnameHook(Task):


### PR DESCRIPTION
An environment with AF_INET6 sockets but no loopback interface creates
nothing but pain.

If an IPv4 server binds to `0.0.0.0:8080`, clients may connect to
`0.0.0.0:8080`, which automatically picks `127.0.0.1` as a source address.
However, when a server binds to `[::]:8080`, the absence of `::1` causes
clients to fail with `ENETUNREACH`.

For a demonstration, run the following in a python shell:

```
import socket
s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM, 0)
s.bind(("", 0))
print s.getsockname()  # Example: ('::', 39079, 0, 0)
s.listen(10)
c = socket.socket(socket.AF_INET6, socket.SOCK_STREAM, 0)
c.connect(s.getsockname())
print c.getsockname(), c.getpeername()
```

This yields the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 101] Network is unreachable
```