### PR TITLE
Add busybox as a required package for GCE.

### DIFF
--- a/bootstrapvz/providers/gce/tasks/packages.py
+++ b/bootstrapvz/providers/gce/tasks/packages.py
@@ -15,6 +15,7 @@ class DefaultPackages(Task):
 	@classmethod
 	def run(cls, info):
 		info.packages.add('acpi-support-base')
+		info.packages.add('busybox')
 		info.packages.add('ca-certificates')
 		info.packages.add('curl')
 		info.packages.add('ethtool')


### PR DESCRIPTION
busybox as a dependency seems to have disappeared at some point in recent PR's and is required for initrd with the growroot disable script that currently exists in GCE images.