### PR TITLE
cloud_init disable AdjustGrowpartWorkaround

### DIFF
--- a/bootstrapvz/plugins/cloud_init/__init__.py
+++ b/bootstrapvz/plugins/cloud_init/__init__.py
@@ -30,4 +30,5 @@ def resolve_tasks(taskset, manifest):
 	taskset.discard(initd_ec2.AddEC2InitScripts)
 	taskset.discard(initd.AddExpandRoot)
 	taskset.discard(initd.AdjustExpandRootScript)
+	taskset.discard(initd.AdjustGrowpartWorkaround)
 	taskset.discard(ssh.AddSSHKeyGeneration)


### PR DESCRIPTION
AdjustGrowpartWorkaround modifies /etc/init.d/expand-root, which doesn't
exist if AddExpandRoot doesn't run.