### PR TITLE
cloud-init: modify groups

### DIFF
--- a/bootstrapvz/plugins/cloud_init/README.rst
+++ b/bootstrapvz/plugins/cloud_init/README.rst
@@ -13,6 +13,9 @@ Settings
 
 -  ``username``: The username of the account to create.
    ``required``
+-  ``groups``: A list of strings specifying which additional groups the account
+   should be added to.
+   ``optional``
 -  ``disable_modules``: A list of strings specifying which cloud-init
    modules should be disabled.
    ``optional``

--- a/bootstrapvz/plugins/cloud_init/__init__.py
+++ b/bootstrapvz/plugins/cloud_init/__init__.py
@@ -24,6 +24,8 @@ def resolve_tasks(taskset, manifest):
 	options = manifest.plugins['cloud_init']
 	if 'username' in options:
 		taskset.add(tasks.SetUsername)
+	if 'groups' in options and len(options['groups']):
+		taskset.add(tasks.SetGroups)
 	if 'disable_modules' in options:
 		taskset.add(tasks.DisableModules)
 

--- a/bootstrapvz/plugins/cloud_init/manifest-schema.yml
+++ b/bootstrapvz/plugins/cloud_init/manifest-schema.yml
@@ -22,6 +22,10 @@ properties:
         type: object
         properties:
           username: {type: string}
+          groups:
+            type: array
+            items: {type: string}
+            uniqueItems: true
           metadata_sources: {type: string}
           disable_modules:
             type: array

--- a/bootstrapvz/plugins/cloud_init/tasks.py
+++ b/bootstrapvz/plugins/cloud_init/tasks.py
@@ -38,6 +38,22 @@ class SetUsername(Task):
 		sed_i(cloud_cfg, search, replace)
 
 
+class SetGroups(Task):
+	description = 'Setting groups in cloud.cfg'
+	phase = phases.system_modification
+
+	@classmethod
+	def run(cls, info):
+		from bootstrapvz.common.tools import sed_i
+		cloud_cfg = os.path.join(info.root, 'etc/cloud/cloud.cfg')
+		groups = info.manifest.plugins['cloud_init']['groups']
+		search = ('^     groups: \[adm, audio, cdrom, dialout, floppy, video,'
+		          ' plugdev, dip\]$')
+		replace = ('     groups: [adm, audio, cdrom, dialout, floppy, video,'
+		           ' plugdev, dip, {groups}]').format(groups=', '.join(groups))
+		sed_i(cloud_cfg, search, replace)
+
+
 class SetMetadataSource(Task):
 	description = 'Setting metadata source'
 	phase = phases.package_installation


### PR DESCRIPTION
Very similar to user customization.

Use case is:
```
...
packages:
  sources:
    docker:
      - deb http://apt.dockerproject.org/repo/ debian-jessie main
  install:
    - docker-engine
plugins:
  cloud_init:
    metadata_sources: Ec2
    username: admin
    groups:
      - docker
```

`docker_daemon` requires Grub due to `EnableMemoryCgroup` and I prefer installing docker from .deb.
`commands` can't `usermod` because the user doesn't exist yet.
I ended up here.