### PR TITLE
Fixes for uploading a GCE image

### DIFF
--- a/bootstrapvz/providers/gce/README.rst
+++ b/bootstrapvz/providers/gce/README.rst
@@ -3,10 +3,14 @@ Google Compute Engine
 
 The `GCE <https://cloud.google.com/products/compute-engine/>`__ provider
 can creates image as expected by GCE - i.e. raw disk image in \*.tar.gz
-file. It can upload created images to Google Storage Engine (to URI
-provided in manifest by ``gcs_destination``) and can register image to
-be used by Google Compute Engine to project provided in manifest by
+file. It can upload created images to Google Cloud Storage (to a URI
+provided in the manifest by ``gcs_destination``) and can register images to
+be used by Google Compute Engine to a project provided in the manifest by
 ``gce_project``. Both of those functionalities are not fully tested yet.
+
+Note that to register an image, it must first be uploaded to GCS, so you must
+specify ``gcs_destination`` (upload to GCS) to use ``gce_project`` (register
+with GCE)
 
 Manifest settings
 -----------------
@@ -15,7 +19,7 @@ Provider
 ~~~~~~~~
 
 -  ``description``: Description of the image.
--  ``gcs_destination``: Image destination in GSE.
+-  ``gcs_destination``: Image destination in GCS.
 -  ``gce_project``: GCE project in which to register the image.
 
 

--- a/bootstrapvz/providers/gce/tasks/image.py
+++ b/bootstrapvz/providers/gce/tasks/image.py
@@ -30,8 +30,11 @@ class CreateTarball(Task):
 		tarball_path = os.path.join(info.manifest.bootstrapper['workspace'], tarball_name)
 		info._gce['tarball_name'] = tarball_name
 		info._gce['tarball_path'] = tarball_path
+                # GCE requires that the file in the tar be named disk.raw, hence the transform
 		log_check_call(['tar', '--sparse', '-C', info.manifest.bootstrapper['workspace'],
-		                '-caf', tarball_path, filename])
+		                '-caf', tarball_path,
+		                '--transform=s|.*|disk.raw|',
+		                filename])
 
 
 class UploadImage(Task):

--- a/bootstrapvz/providers/gce/tasks/image.py
+++ b/bootstrapvz/providers/gce/tasks/image.py
@@ -12,16 +12,8 @@ class CreateTarball(Task):
 
 	@classmethod
 	def run(cls, info):
-		import datetime
 		image_name = info.manifest.name.format(**info.manifest_vars)
 		filename = image_name + '.' + info.volume.extension
-		today = datetime.datetime.today()
-		name_suffix = today.strftime('%Y%m%d')
-		image_name_format = '{lsb_distribution}-{lsb_release}-{release}-v{name_suffix}'
-		image_name = image_name_format.format(lsb_distribution=info._gce['lsb_distribution'],
-		                                      lsb_release=info._gce['lsb_release'],
-		                                      release=info.manifest.system['release'],
-		                                      name_suffix=name_suffix)
 		# ensure that we do not use disallowed characters in image name
 		image_name = image_name.lower()
 		image_name = image_name.replace(".", "-")

--- a/bootstrapvz/providers/gce/tasks/image.py
+++ b/bootstrapvz/providers/gce/tasks/image.py
@@ -56,6 +56,6 @@ class RegisterImage(Task):
 		if 'description' in info.manifest.provider:
 			image_description = info.manifest.provider['description']
 		log_check_call(['gcloud', 'compute', '--project=' + info.manifest.provider['gce_project'],
-		                'image', 'create', info._gce['image_name'], '--source-uri=',
-		                info.manifest.provider['gcs_destination'] + info._gce['tarball_name'],
+		                'images', 'create', info._gce['image_name'],
+		                '--source-uri=' + info.manifest.provider['gcs_destination'] + info._gce['tarball_name'],
 		                '--description=' + image_description])

--- a/bootstrapvz/providers/gce/tasks/image.py
+++ b/bootstrapvz/providers/gce/tasks/image.py
@@ -55,6 +55,7 @@ class RegisterImage(Task):
 		image_description = info._gce['lsb_description']
 		if 'description' in info.manifest.provider:
 			image_description = info.manifest.provider['description']
+			image_description = image_description.format(**info.manifest_vars)
 		log_check_call(['gcloud', 'compute', '--project=' + info.manifest.provider['gce_project'],
 		                'images', 'create', info._gce['image_name'],
 		                '--source-uri=' + info.manifest.provider['gcs_destination'] + info._gce['tarball_name'],


### PR DESCRIPTION
GCE image upload simply didn't work.  With this PR, it does.  Changes:

* syntax is `gcloud compute images`, not `gcloud compute image`
* --source-uri=<uri> should be a single argument
* Expand the description template before passing it to gcloud
* Rename image in tar file to disk.raw
* Name the image as specified in the manifest
* Documentation improvements