### PR TITLE
Disable SSH root login on GCE images.

### DIFF
--- a/bootstrapvz/providers/gce/__init__.py
+++ b/bootstrapvz/providers/gce/__init__.py
@@ -46,6 +46,7 @@ def resolve_tasks(taskset, manifest):
 	                boot.UpdateInitramfs,
 	                ssh.AddSSHKeyGeneration,
 	                ssh.DisableSSHPasswordAuthentication,
+	                ssh.DisableRootLogin,
 	                tasks.apt.CleanGoogleRepositoriesAndKeys,
 
 	                image.MoveImage,


### PR DESCRIPTION
We thought this was already set but it seems to have changed at some point in history (functionally in Debian configs of boostrap-vz).
https://cloud.google.com/compute/docs/instances/connecting-to-instance#root