### PR TITLE
console=ttyS0 for kvm and virtualbox

### DIFF
--- a/bootstrapvz/providers/kvm/__init__.py
+++ b/bootstrapvz/providers/kvm/__init__.py
@@ -1,5 +1,6 @@
 from bootstrapvz.common import task_groups
 import tasks.packages
+import tasks.boot
 from bootstrapvz.common.tasks import image
 from bootstrapvz.common.tasks import loopback
 from bootstrapvz.common.tasks import initd
@@ -23,6 +24,7 @@ def resolve_tasks(taskset, manifest):
 	                ssh.ShredHostkeys,
 	                ssh.AddSSHKeyGeneration,
 	                image.MoveImage,
+	                tasks.boot.ConfigureGrub,
 	                ])
 
 	if manifest.provider.get('virtio', []):

--- a/bootstrapvz/providers/kvm/tasks/boot.py
+++ b/bootstrapvz/providers/kvm/tasks/boot.py
@@ -1,0 +1,18 @@
+from bootstrapvz.base import Task
+from bootstrapvz.common import phases
+from bootstrapvz.common.tasks import grub
+import os
+
+
+class ConfigureGrub(Task):
+	description = 'Change grub configuration to allow for ttyS0 output'
+	phase = phases.system_modification
+	predecessors = [grub.ConfigureGrub]
+	successors = [grub.InstallGrub_1_99, grub.InstallGrub_2]
+
+	@classmethod
+	def run(cls, info):
+		from bootstrapvz.common.tools import sed_i
+		grub_def = os.path.join(info.root, 'etc/default/grub')
+		sed_i(grub_def, '^GRUB_CMDLINE_LINUX_DEFAULT="console=hvc0"',
+		                'GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0"')

--- a/bootstrapvz/providers/virtualbox/__init__.py
+++ b/bootstrapvz/providers/virtualbox/__init__.py
@@ -1,5 +1,6 @@
 from bootstrapvz.common import task_groups
 import tasks.packages
+import tasks.boot
 from bootstrapvz.common.tasks import image
 from bootstrapvz.common.tasks import loopback
 
@@ -17,6 +18,7 @@ def resolve_tasks(taskset, manifest):
 	                loopback.AddRequiredCommands,
 	                loopback.Create,
 	                image.MoveImage,
+	                tasks.boot.ConfigureGrub,
 	                ])
 
 	if manifest.provider.get('guest_additions', False):

--- a/bootstrapvz/providers/virtualbox/tasks/boot.py
+++ b/bootstrapvz/providers/virtualbox/tasks/boot.py
@@ -1,0 +1,18 @@
+from bootstrapvz.base import Task
+from bootstrapvz.common import phases
+from bootstrapvz.common.tasks import grub
+import os
+
+
+class ConfigureGrub(Task):
+	description = 'Change grub configuration to allow for ttyS0 output'
+	phase = phases.system_modification
+	predecessors = [grub.ConfigureGrub]
+	successors = [grub.InstallGrub_1_99, grub.InstallGrub_2]
+
+	@classmethod
+	def run(cls, info):
+		from bootstrapvz.common.tools import sed_i
+		grub_def = os.path.join(info.root, 'etc/default/grub')
+		sed_i(grub_def, '^GRUB_CMDLINE_LINUX_DEFAULT="console=hvc0"',
+		                'GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0"')


### PR DESCRIPTION
This definitely fixes my issue, 318, and I suspect that it fixes 312 as well but I haven't tested.  I have my doubts about this being the right solution... the majority of providers now hack in ttys0, which makes me think that the original change to grub (608de63d3ed4a365d6409007805d73d1f2ea909a) may be in error.

An alternative to this change is to standardize on ttys0 in common/tasks/grub.py and use hvc0 only where needed.  To take that route, though, I'd need to know why the original move to hvc0 was made, so I'll leave that judgement up to Anders.

Fixes: https://github.com/andsens/bootstrap-vz/issues/318
Fixes: https://github.com/andsens/bootstrap-vz/issues/312