### PR TITLE
Set a default of GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0"

### DIFF
--- a/bootstrapvz/common/tasks/grub.py
+++ b/bootstrapvz/common/tasks/grub.py
@@ -27,7 +27,7 @@ class ConfigureGrub(Task):
 		grub_def = os.path.join(info.root, 'etc/default/grub')
 		sed_i(grub_def, '^#GRUB_TERMINAL=console', 'GRUB_TERMINAL=console')
 		sed_i(grub_def, '^GRUB_CMDLINE_LINUX_DEFAULT="quiet"',
-		                'GRUB_CMDLINE_LINUX_DEFAULT="console=hvc0"')
+		                'GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0"')
 		sed_i(grub_def, '^GRUB_TIMEOUT=[0-9]+', 'GRUB_TIMEOUT=0\n'
 		                                        'GRUB_HIDDEN_TIMEOUT=0\n'
 		                                        'GRUB_HIDDEN_TIMEOUT_QUIET=true')


### PR DESCRIPTION
This needed changing to hvc0 for ec2, and was accidentally changed
for all other providers.  Since the ec2 provider overrides to hvc0
anyway, we can just change this default to the setting that works
for everyone else.

Fixes: #318