### PR TITLE
Fix some GCE image issues.

### DIFF
--- a/bootstrapvz/providers/gce/__init__.py
+++ b/bootstrapvz/providers/gce/__init__.py
@@ -1,4 +1,5 @@
 from bootstrapvz.common import task_groups
+import tasks.apt
 import tasks.boot
 import tasks.configuration
 import tasks.image
@@ -25,6 +26,7 @@ def resolve_tasks(taskset, manifest):
     taskset.update(task_groups.get_standard_groups(manifest))
 
     taskset.update([apt.AddBackports,
+                    apt.AddDefaultSources,
                     loopback.AddRequiredCommands,
                     loopback.Create,
                     tasks.packages.DefaultPackages,
@@ -40,6 +42,7 @@ def resolve_tasks(taskset, manifest):
                     ssh.AddSSHKeyGeneration,
                     ssh.DisableSSHPasswordAuthentication,
                     ssh.DisableRootLogin,
+                    tasks.apt.AddBaselineAptCache,
                     image.MoveImage,
                     tasks.image.CreateTarball,
                     volume.Delete,

--- a/bootstrapvz/providers/gce/tasks/apt.py
+++ b/bootstrapvz/providers/gce/tasks/apt.py
@@ -1,0 +1,16 @@
+from bootstrapvz.base import Task
+from bootstrapvz.common import phases
+from bootstrapvz.common.tasks import apt
+from bootstrapvz.common.tasks import network
+from bootstrapvz.common.tools import log_check_call
+
+
+class AddBaselineAptCache(Task):
+    description = 'Add a baseline apt cache into the image.'
+    phase = phases.system_cleaning
+    predecessors = [apt.AptClean]
+    successors = [network.RemoveDNSInfo]
+
+    @classmethod
+    def run(cls, info):
+        log_check_call(['chroot', info.root, 'apt-get', 'update'])

--- a/manifests/official/gce/README.rst
+++ b/manifests/official/gce/README.rst
@@ -11,10 +11,11 @@ Debian 8 Jessie Package Notes:
 * cloud-utils and cloud-guest-utils are pulled in from backports as they provide a fixed version of growpart to safely grow the root partition on disks >2TB.
 * google-cloud-sdk is pulled from a Google Cloud repository.
 * google-compute-engine is pulled from a Google Cloud repository.
+* google-compute-engine-init is pulled from a Google Cloud repository.
 * google-config is pulled from a Google Cloud repository.
 
 jessie-minimal Notes:
-The only additions are the necessary google-compute-engine and google-config packages. This image is not published on GCE however the manifest is provided here for those wishing a minimal GCE Debian image.
+The only additions are the necessary google-compute-engine, google-compute-engine-init, and google-config packages. This image is not published on GCE however the manifest is provided here for those wishing a minimal GCE Debian image.
 
 Note: Debian 7 Wheezy and Backports Debian 7 Wheezy are deprecated images on GCE and are no longer supported.
 These manifests are provided here for historic purposes.

--- a/manifests/official/gce/jessie-minimal.yml
+++ b/manifests/official/gce/jessie-minimal.yml
@@ -20,11 +20,13 @@ volume:
       filesystem: ext4
       size: 10GiB
 packages:
+  include-source-type: true
   sources:
     google-cloud:
       - deb http://packages.cloud.google.com/apt google-cloud-compute-{system.release} main
   install:
     - google-compute-engine-{system.release}
+    - google-compute-engine-init-{system.release}
     - google-config-{system.release}
 plugins:
   google_cloud_repo:

--- a/manifests/official/gce/jessie.yml
+++ b/manifests/official/gce/jessie.yml
@@ -20,6 +20,7 @@ volume:
       filesystem: ext4
       size: 10GiB
 packages:
+  include-source-type: true
   sources:
     google-cloud:
       - deb http://packages.cloud.google.com/apt cloud-sdk-{system.release} main
@@ -29,6 +30,7 @@ packages:
     - cloud-utils
     - google-cloud-sdk
     - google-compute-engine-{system.release}
+    - google-compute-engine-init-{system.release}
     - google-config-{system.release}
     - python-crcmod
     - screen


### PR DESCRIPTION
Fix missing source repo's in GCE images. Add back baseline apt cache as well. Add in additional GCE guest package into manifests (init files were split into their own package to make the python package adhere to pypi standards).