### PR TITLE
docker: Fix quoting that breaks some versions of Docker

### DIFF
--- a/bootstrapvz/providers/docker/tasks/image.py
+++ b/bootstrapvz/providers/docker/tasks/image.py
@@ -50,15 +50,9 @@ class PopulateLabels(Task):
             for label, value in info.manifest.provider['labels'].items():
                 labels[label] = value.format(**info.manifest_vars)
 
-        # pipes.quote converts newlines into \n rather than just prefixing
-        # it with a backslash, so we need to escape manually
-        def escape(value):
-            value = value.replace('"', '\\"')
-            value = value.replace('\n', '\\\n')
-            value = '"' + value + '"'
-            return value
+        from pipes import quote
         for label, value in labels.items():
-            info._docker['dockerfile'].append('LABEL {}={}'.format(label, escape(value)))
+            info._docker['dockerfile'].append('LABEL {}={}'.format(label, quote(value)))
 
 
 class AppendManifestDockerfile(Task):


### PR DESCRIPTION
The extra quoting breaks on some versions of Docker, such as the one available on Travis.

See <https://travis-ci.org/hashbang/docker-gitolite/builds/151947017#L527> for a build log.