### PR TITLE
apt: Validate packages.trusted-keys

### DIFF
--- a/bootstrapvz/common/phases.py
+++ b/bootstrapvz/common/phases.py
@@ -1,5 +1,6 @@
 from bootstrapvz.base.phase import Phase
 
+validation = Phase('Validation', 'Validating data, files, etc.')
 preparation = Phase('Preparation', 'Initializing connections, fetching data etc.')
 volume_creation = Phase('Volume creation', 'Creating the volume to bootstrap onto')
 volume_preparation = Phase('Volume preparation', 'Formatting the bootstrap volume')
@@ -13,7 +14,8 @@ volume_unmounting = Phase('Volume unmounting', 'Unmounting the bootstrap volume'
 image_registration = Phase('Image registration', 'Uploading/Registering with the provider')
 cleaning = Phase('Cleaning', 'Removing temporary files')
 
-order = [preparation,
+order = [validation,
+         preparation,
          volume_creation,
          volume_preparation,
          volume_mounting,

--- a/bootstrapvz/common/task_groups.py
+++ b/bootstrapvz/common/task_groups.py
@@ -121,6 +121,7 @@ def get_apt_group(manifest):
     if 'sources' in manifest.packages:
         group.append(apt.AddManifestSources)
     if 'trusted-keys' in manifest.packages:
+        group.append(apt.ValidateTrustedKeys)
         group.append(apt.InstallTrustedKeys)
     if 'preferences' in manifest.packages:
         group.append(apt.AddManifestPreferences)


### PR DESCRIPTION
This makes wrong (inexistent or malformed) trusted-keys
keyring fail the image build at validation-time, rather
than in the package installation phase.