### PR TITLE
Added tagging for the created images +

### DIFF
--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -47,10 +47,10 @@ properties:
         enum: [i386]
       bootloader:
         enum:
-        - pvgrub
-        - grub
-        - extlinux
-        - none
+          - pvgrub
+          - grub
+          - extlinux
+          - none
       charmap: {type: string}
       hostname:
         type: string
@@ -59,12 +59,12 @@ properties:
       release: {type: string}
       timezone: {type: string}
     required:
-    - release
-    - architecture
-    - bootloader
-    - timezone
-    - locale
-    - charmap
+      - release
+      - architecture
+      - bootloader
+      - timezone
+      - locale
+      - charmap
     additionalProperties: false
   packages:
     type: object
@@ -77,8 +77,8 @@ properties:
         type: array
         items:
           anyOf:
-          - pattern: ^[^/]+(/[^/]+)?$
-          - $ref: '#/definitions/absolute_path'
+            - pattern: ^[^/]+(/[^/]+)?$
+            - $ref: '#/definitions/absolute_path'
         minItems: 1
       install_standard: {type: boolean}
       mirror:
@@ -137,8 +137,8 @@ properties:
       partitions:
         type: object
         oneOf:
-        - $ref: '#/definitions/no_partitions'
-        - $ref: '#/definitions/partition_table'
+          - $ref: '#/definitions/no_partitions'
+          - $ref: '#/definitions/partition_table'
     required: [partitions]
     additionalProperties: false
 definitions:

--- a/bootstrapvz/base/manifest.py
+++ b/bootstrapvz/base/manifest.py
@@ -110,7 +110,7 @@ class Manifest(object):
         self.system       = self.data['system']
         from bootstrapvz.common.releases import get_release
         self.release      = get_release(self.system['release'])
-        # The packages and plugins section is not required
+        # The packages and plugins sections are not required
         self.packages     = self.data['packages'] if 'packages' in self.data else {}
         self.plugins      = self.data['plugins'] if 'plugins' in self.data else {}
 

--- a/bootstrapvz/providers/ec2/__init__.py
+++ b/bootstrapvz/providers/ec2/__init__.py
@@ -49,6 +49,9 @@ def validate_manifest(data, validator, error):
 
 
 def resolve_tasks(taskset, manifest):
+    """
+    Function setting up tasks to run for this provider
+    """
     from bootstrapvz.common.releases import wheezy, jessie, stable
 
     taskset.update(task_groups.get_standard_groups(manifest))

--- a/bootstrapvz/providers/ec2/manifest-schema.yml
+++ b/bootstrapvz/providers/ec2/manifest-schema.yml
@@ -3,6 +3,9 @@ $schema: http://json-schema.org/draft-04/schema#
 title: EC2 manifest
 type: object
 properties:
+  tags:
+    type: object
+    minProperties: 1
   provider:
     type: object
     properties:
@@ -14,12 +17,12 @@ properties:
           secret-key: {type: string}
       virtualization:
         enum:
-        - pvm
-        - hvm
+          - pvm
+          - hvm
       enhanced_networking:
         enum:
-        - none
-        - simple
+          - none
+          - simple
     required: [description, virtualization]
   system:
     type: object
@@ -27,22 +30,22 @@ properties:
       bootloader:
         type: string
         enum:
-        - pvgrub
-        - grub
-        - extlinux
+          - pvgrub
+          - grub
+          - extlinux
   volume:
     type: object
     properties:
       backing:
         enum:
-        - ebs
-        - s3
+          - ebs
+          - s3
       partitions:
         type: object
         properties:
           type:
             enum:
-            - none
-            - msdos
-            - gpt
+              - none
+              - msdos
+              - gpt
     required: [backing]

--- a/bootstrapvz/providers/ec2/tasks/ami.py
+++ b/bootstrapvz/providers/ec2/tasks/ami.py
@@ -125,3 +125,9 @@ class RegisterAMI(Task):
             registration_params['sriov_net_support'] = 'simple'
 
         info._ec2['image'] = info._ec2['connection'].register_image(**registration_params)
+
+        # Setting up tags on the AMI
+        if 'tags' in info.manifest.data:
+            raw_tags = info.manifest.data['tags']
+            tags = {k: v.format(**info.manifest_vars) for k, v in raw_tags.items()}
+            info._ec2['connection'].create_tags(info._ec2['image'], tags)

--- a/manifests/official/ec2/ebs-stretch-amd64-hvm.yml
+++ b/manifests/official/ec2/ebs-stretch-amd64-hvm.yml
@@ -1,5 +1,8 @@
 ---
-name: debian-{system.release}-{system.architecture}-{provider.virtualization}-{%Y}-{%m}-{%d}-ebs
+name: debian-{system.release}-{system.architecture}-{provider.virtualization}-{%Y}-{%m}-{%d}-{%H}{%M}-ebs
+tags:
+  Name: "Stretch 9.0 alpha"
+  Debian: "9.0~{%Y}{%m}{%d}"
 provider:
   name: ec2
   virtualization: hvm
@@ -11,7 +14,7 @@ provider:
 bootstrapper:
   workspace: /target
 system:
-  release: jessie
+  release: stretch
   architecture: amd64
   bootloader: grub
   charmap: UTF-8
@@ -30,11 +33,6 @@ packages:
     - main
     - contrib
     - non-free
-  preferences:
-    backport-cloud-init-cloud-utils:
-      - package: cloud-init cloud-utils
-        pin: release n=jessie-backports
-        pin-priority: 500
   install:
     - awscli
     - python-boto
@@ -55,3 +53,14 @@ plugins:
     enable_modules:
       cloud_init_modules:
         - {module: growpart, position: 4}
+#  ec2_launch:
+#    security_group_ids:
+#      # this have to be a NONE VPC SG
+#      - sg-398a704f
+#    instance_type: m3.medium
+#    ssh_key: my_ssh_key
+#    print_public_ip: "/tmp/stretch-ami-test-ip"
+#    tags:
+#      Name: "testing-ami-{system.release}"
+#      Debian: "9.0~{%Y}{%m}{%d}{%H}{%M}"
+#    deregister_ami: false


### PR DESCRIPTION
- fully implemented for EC2 provider only, other providers will require
  validation and applying to the instances added
- brand new Stretch manifest with top level AMI tags
- some minor Jessie manifest editorials
- some minor yaml schema editorials
