### PR TITLE
Support ca-central-1

### DIFF
--- a/bootstrapvz/plugins/ec2_publish/manifest-schema.yml
+++ b/bootstrapvz/plugins/ec2_publish/manifest-schema.yml
@@ -23,6 +23,7 @@ definitions:
     - ap-northeast-2
     - ap-southeast-1
     - ap-southeast-2
+    - ca-central-1
     - eu-central-1
     - eu-west-1
     - sa-east-1

--- a/bootstrapvz/providers/ec2/manifest-schema-s3.yml
+++ b/bootstrapvz/providers/ec2/manifest-schema-s3.yml
@@ -26,6 +26,7 @@ definitions:
     - ap-northeast-2
     - ap-southeast-1
     - ap-southeast-2
+    - ca-central-1
     - eu-central-1
     - eu-west-1
     - sa-east-1

--- a/bootstrapvz/providers/ec2/tasks/ami-akis.yml
+++ b/bootstrapvz/providers/ec2/tasks/ami-akis.yml
@@ -34,3 +34,5 @@ us-west-2:
 cn-north-1:
   amd64: aki-9e8f1da7
   i386: aki-908f1da9
+ca-central-1:
+  amd64: aki-320ebd56


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2016/12/announcing-the-aws-canada-central-region/ 🇨🇦 !

This may not be usable yet: `aws ec2 describe-images --owners amazon --filters Name=name,Values=pv-grub-*.gz --region ca-central-1` doesn't output an i386 kernel.