### PR TITLE
Fix subprocess call to verify admin_user public key

### DIFF
--- a/bootstrapvz/plugins/admin_user/tasks.py
+++ b/bootstrapvz/plugins/admin_user/tasks.py
@@ -23,7 +23,7 @@ class CheckPublicKeyFile(Task):
                 msg = 'Could not find public key at %s' % pubkey
                 info.manifest.validation_error(msg, ['plugins', 'admin_user', 'pubkey'])
 
-            ret, _, stderr = log_call('ssh-keygen -l -f ' + abs_pubkey)
+            ret, _, stderr = log_call(['ssh-keygen', '-l', '-f', abs_pubkey])
             if ret != 0:
                 msg = 'Invalid public key file at %s' % pubkey
                 info.manifest.validation_error(msg, ['plugins', 'admin_user', 'pubkey'])


### PR DESCRIPTION
In the current state, if you were to specify a pubkey under the admin_user plugin, bootstrap fails with the following error:

```
Generating tasklist
Adding commands required for formatting
Adding commands required for partitioning the volume
Check that the public key is a valid file
[Errno 2] No such file or directory
Traceback (most recent call last):
  File "/root/bootstrap-vz/bootstrapvz/base/main.py", line 111, in run
    tasklist.run(info=bootstrap_info, dry_run=dry_run)
  File "/root/bootstrap-vz/bootstrapvz/base/tasklist.py", line 44, in run
    task.run(info)
  File "/root/bootstrap-vz/bootstrapvz/plugins/admin_user/tasks.py", line 26, in run
    ret, _, stderr = log_call('/usr/bin/ssh-keygen -l -f ' + abs_pubkey)
  File "/root/bootstrap-vz/bootstrapvz/common/tools.py", line 33, in log_call
    stderr=subprocess.PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
Rolling back
Successfully completed rollback
Traceback (most recent call last):
  File "./bootstrap-vz", line 5, in <module>
    main()
  File "/root/bootstrap-vz/bootstrapvz/base/main.py", line 29, in main
    dry_run=opts['--dry-run'])
  File "/root/bootstrap-vz/bootstrapvz/base/main.py", line 111, in run
    tasklist.run(info=bootstrap_info, dry_run=dry_run)
  File "/root/bootstrap-vz/bootstrapvz/base/tasklist.py", line 44, in run
    task.run(info)
  File "/root/bootstrap-vz/bootstrapvz/plugins/admin_user/tasks.py", line 26, in run
    ret, _, stderr = log_call('/usr/bin/ssh-keygen -l -f ' + abs_pubkey)
  File "/root/bootstrap-vz/bootstrapvz/common/tools.py", line 33, in log_call
    stderr=subprocess.PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

This seems to be because subprocess is called with shell=False, this, in turn, causes the string 'ssh-keygen -l -f' to be interpreted as a command (including the spaces), hence the File not found error.

This is fixed by passing the command as elements in a list to subprocess.