### PR TITLE
Fix an ordering issue with the expand-root plugin.

### DIFF
--- a/bootstrapvz/plugins/expand_root/tasks.py
+++ b/bootstrapvz/plugins/expand_root/tasks.py
@@ -1,7 +1,7 @@
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
+from bootstrapvz.common.tasks import apt
 from bootstrapvz.common.tasks import initd
-from bootstrapvz.common.tasks import packages
 from bootstrapvz.common.tools import log_check_call
 from bootstrapvz.common.tools import rel_path
 from bootstrapvz.common.tools import sed_i
@@ -14,7 +14,7 @@ ASSETS_DIR = rel_path(__file__, 'assets')
 class InstallGrowpart(Task):
     description = 'Adding necessary packages for growpart.'
     phase = phases.preparation
-    successors = [packages.AddManifestPackages]
+    predecessors = [apt.AddBackports]
 
     @classmethod
     def run(cls, info):


### PR DESCRIPTION
For whatever reason, there was an ordering issue where this class was being run before anything else and failing because there wasn't a jessie-backports sources list yet (not to mention a filesytem at all). Moving this to the package_installation phase fixes the problem.