### PR TITLE
fix some typos in documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -123,7 +123,7 @@ Stephen A. Zarkos:
     * Azure: Change Wheezy image to use single partition
     * Azure: Update WALinuxAgent to use 2.0.14
     * Azure: Make sure we can override grub.ConfigureGrub for Azure images
-    * Azure: Add console=tty0 to see kernel/boot messsages on local console
+    * Azure: Add console=tty0 to see kernel/boot messages on local console
     * Azure: Set serial port speed to 115200
     * Azure: Fix error with applying azure/assets/udev.diff
 
@@ -191,7 +191,7 @@ Anders Ingemann (work started 2014-08-31, merged on 2015-04-25):
     * Take @ssgelm's advice in #155 and copy the mount table -- df warnings no more
     * Generally deny installing grub on squeeze (too much of a hassle to get working, PRs welcome)
     * Add 1 sector gap between partitions on GPT
-    * Add new task: DeterminKernelVersion, this can potentially fix a lot of small problems
+    * Add new task: DetermineKernelVersion, this can potentially fix a lot of small problems
     * Disable getty processes on jessie through logind config
     * Partition volumes by sectors instead of bytes
       This allows for finer grained control over the partition sizes and gaps

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -82,7 +82,7 @@ Roll complexity into which tasks are added to the tasklist
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If a ``run()`` function checks whether it should do any work or simply be
 skipped, consider doing that check in ``resolve_tasks()`` instead and
-avoid adding that task alltogether. This allows people looking at the
+avoid adding that task altogether. This allows people looking at the
 tasklist in the logfile to determine what work has been performed.
 
 If a task says it will modify a file but then bails , a developer may get

--- a/bootstrapvz/plugins/admin_user/README.rst
+++ b/bootstrapvz/plugins/admin_user/README.rst
@@ -4,6 +4,7 @@ Admin user
 This plugin creates a user with passwordless sudo privileges. It also
 disables the SSH root login. There are three ways to grant access to
 the admin user:
+
 -  Use the EC2 public key (EC2 machines only)
 -  Set a password for the user
 -  Provide a SSH public key to allow remote SSH login

--- a/bootstrapvz/plugins/expand_root/README.rst
+++ b/bootstrapvz/plugins/expand_root/README.rst
@@ -4,7 +4,7 @@ Expand Root
 This plugin adds support to expand the root partition and filesystem dynamically on boot. It adds a shell script to call growpart and the proper filesystem expansion tool for a given device, partition, and filesystem. The growpart script is part of the cloud-guest-utils package in stretch and jessie-backports. The version of this script in jessie is broken in several ways and so this plugin installs the version from jessie-backports which works correctly. This plugin should not be used in conjunction with common.tasks.initd.AddExpandRoot and common.tasks.initd.AdjustExpandRootScript. It is meant to replace the existing internal common version of expand-root.
 
 Settings
---------
+~~~~~~~~
 
 -  ``filesystem_type``: The type of filesystem to grow, one of ext2, ext3, ext4, of xfs.
 -  ``root_device``: The root device we are growing, /dev/sda as an example.

--- a/bootstrapvz/plugins/google_cloud_repo/README.rst
+++ b/bootstrapvz/plugins/google_cloud_repo/README.rst
@@ -4,7 +4,7 @@ Google Cloud Repo
 This plugin adds support to use Google Cloud apt repositories for Debian. It adds the public repo key and optionally will add an apt source list file and install a package containing the key in order to maintain the key over time.
 
 Settings
---------
+~~~~~~~~
 
 -  ``cleanup_bootstrap_key``: Deletes the bootstrap key by removing /etc/apt/trusted.gpg in favor of the package maintained version. This is only to avoid having multiple keys around in the apt-key list. This should only be used with enable_keyring_repo.
 -  ``enable_keyring_repo``: Add a repository and package to maintain the repo public key over time.

--- a/bootstrapvz/remote/README.rst
+++ b/bootstrapvz/remote/README.rst
@@ -119,7 +119,7 @@ automatically forwarded through an SSH tunnel).
 self explanatory (remote machine address, SSH port, login name and path to
 private SSH key file).
 
-``server_bin`` refers to the `aboved mentioned <#bootstrap-vz-remote>`__
+``server_bin`` refers to the `abovementioned <#bootstrap-vz-remote>`__
 bootstrap-vz-server executable. This is the command bootstrap-vz executes
 on the remote machine to start the RPC server.
 

--- a/manifests/README.rst
+++ b/manifests/README.rst
@@ -312,7 +312,7 @@ boot, root and swap.
    -  ``noexec``
    -  ``journal_ioprio=3``
 
-   The default command used by boostrap-vz is
+   The default command used by bootstrap-vz is
    ``['mkfs.{fs}', '{device_path}']``.
 
    -  ``boot``: Configuration of the boot partition. All settings equal 


### PR DESCRIPTION
I have found some typos and layout inconsistencies in the documentation. This is a pull request with fixes for your consideration.