### PR TITLE
Enable SCSI block multiqueue for GCE Stretch images.

### DIFF
--- a/bootstrapvz/providers/gce/tasks/boot.py
+++ b/bootstrapvz/providers/gce/tasks/boot.py
@@ -12,3 +12,7 @@ class ConfigureGrub(Task):
     def run(cls, info):
         info.grub_config['GRUB_CMDLINE_LINUX'].append('console=ttyS0,38400n8')
         info.grub_config['GRUB_CMDLINE_LINUX'].append('elevator=noop')
+        # Enable SCSI block multiqueue on Stretch.
+        from bootstrapvz.common.releases import stretch
+        if info.manifest.release >= stretch:
+            info.grub_config['GRUB_CMDLINE_LINUX'].append('scsi_mod.use_blk_mq=Y')


### PR DESCRIPTION
Note this feature will only work in kernels >3.19 and is only relevant in GCE. I can't speak to other platforms as this is a virtual device level feature.