### PR TITLE
Fix loopdevice partitions not being unmapped correctly

### DIFF
--- a/bootstrapvz/common/fs/loopbackvolume.py
+++ b/bootstrapvz/common/fs/loopbackvolume.py
@@ -15,7 +15,7 @@ class LoopbackVolume(Volume):
         log_check_call(['truncate', size_opt, self.image_path])
 
     def _before_attach(self, e):
-        [self.loop_device_path] = log_check_call(['losetup', '--show', '--find', self.image_path])
+        [self.loop_device_path] = log_check_call(['losetup', '--show', '--find', '--partscan', self.image_path])
         self.device_path = self.loop_device_path
 
     def _before_detach(self, e):


### PR DESCRIPTION
Removes undeleted loopdevice partitions created by kpartx.
This was needed as "bootstrap-vz tries very hard to clean up after itself " and because LVM tries to read from these files and gives off warnings.
Since Util-linux 2.21, losetup is able to scan the partition table of the newly created loop device. Therefore it is able to unmap them as well. By adding a --partscan, losetup tries to map the partitions when the loop device is mounted, and will unmap them when it is detached.