### PR TITLE
Complete PATH for distributions that only have "/usr/bin" in PATH

### DIFF
--- a/bootstrapvz/base/main.py
+++ b/bootstrapvz/base/main.py
@@ -22,6 +22,10 @@ def main():
     from manifest import Manifest
     manifest = Manifest(path=opts['MANIFEST'])
 
+    # Set-up Architecture independent path
+    if "usr/sbin" not in os.environ["PATH"]:
+        os.environ["PATH"] += os.pathsep + os.pathsep.join(["/usr/sbin", "/sbin", "/bin"])
+
     # Everything has been set up, begin the bootstrapping process
     run(manifest,
         debug=opts['--debug'],


### PR DESCRIPTION
Bootstrap-vz expects to have a path that contains /bin, /sbin and
/usr/sbin, but some distributions (Archlinux for example)
have all these directories merged into /usr/bin.