### PR TITLE
Fix unfailing CheckExternalCommands

### DIFF
--- a/bootstrapvz/common/tasks/host.py
+++ b/bootstrapvz/common/tasks/host.py
@@ -9,14 +9,14 @@ class CheckExternalCommands(Task):
 
     @classmethod
     def run(cls, info):
-        from ..tools import log_check_call
-        from subprocess import CalledProcessError
         import re
+        import logging
+        from distutils.spawn import find_executable
         missing_packages = []
+        log = logging.getLogger(__name__)
         for command, package in info.host_dependencies.items():
-            try:
-                log_check_call(['type', command], shell=True)
-            except CalledProcessError:
+            log.debug('Checking availability of ' + command)
+            if find_executable(command) is None:
                 if re.match('^https?:\/\/', package):
                     msg = ('The command `{command}\' is not available, '
                            'you can download the software at `{package}\'.'

--- a/bootstrapvz/common/tasks/host.py
+++ b/bootstrapvz/common/tasks/host.py
@@ -10,13 +10,15 @@ class CheckExternalCommands(Task):
     @classmethod
     def run(cls, info):
         import re
+        import os
         import logging
         from distutils.spawn import find_executable
         missing_packages = []
         log = logging.getLogger(__name__)
         for command, package in info.host_dependencies.items():
             log.debug('Checking availability of ' + command)
-            if find_executable(command) is None:
+            path = find_executable(command)
+            if path is None or not os.access(path, os.X_OK):
                 if re.match('^https?:\/\/', package):
                     msg = ('The command `{command}\' is not available, '
                            'you can download the software at `{package}\'.'


### PR DESCRIPTION
On Unix, with `shell=True`, the shell default to /bin/sh.
Using `Popen(['type', command], shell=True)` is equivalent to calling
`Popen(['/bin/sh', '-c', 'type', command])`.
In this case `'command'` becomes a positional parameter to the shell,
and not an argument to the command `'type'`.

One solution would be to pass a single string as parameter.
The problem is that with `shell=True`, we wouldn't be safe from a shell injection,
so it is wiser to use a python only solution.

The package distutils is part of the standard distribution, so it doesn't add
extra dependencies.
The method find_executable has the same behaviour as 'which' on bash, it 
will return the path to the executable or `None` if it was not found.

Logging needs to be added as it was previously handled by log_check_call().

This fixes [#380](https://github.com/andsens/bootstrap-vz/issues/380) which was broken [here](https://github.com/andsens/bootstrap-vz/commit/bb41ba68dd70ef20518fbe7969accaff93c22300).