### PR TITLE
Add qcow2 as a disk backend for KVM

### DIFF
--- a/bootstrapvz/base/fs/__init__.py
+++ b/bootstrapvz/base/fs/__init__.py
@@ -26,6 +26,7 @@ def load_volume(data, bootloader):
     from bootstrapvz.common.fs.virtualmachinedisk import VirtualMachineDisk
     from bootstrapvz.common.fs.folder import Folder
     from bootstrapvz.common.fs.logicalvolume import LogicalVolume
+    from bootstrapvz.common.fs.qcow2volume import Qcow2Volume
     volume_backing = {'raw': LoopbackVolume,
                       's3':  LoopbackVolume,
                       'vdi': VirtualDiskImage,
@@ -33,7 +34,8 @@ def load_volume(data, bootloader):
                       'vmdk': VirtualMachineDisk,
                       'ebs': EBSVolume,
                       'folder': Folder,
-                      'lvm': LogicalVolume
+                      'lvm': LogicalVolume,
+                      'qcow2': Qcow2Volume
                       }.get(data['backing'])
 
     # Instantiate the partition map

--- a/bootstrapvz/common/fs/qcow2volume.py
+++ b/bootstrapvz/common/fs/qcow2volume.py
@@ -1,0 +1,7 @@
+from qemuvolume import QEMUVolume
+
+
+class Qcow2Volume(QEMUVolume):
+
+    extension = 'qcow2'
+    qemu_format = 'qcow2'

--- a/bootstrapvz/providers/kvm/README.rst
+++ b/bootstrapvz/providers/kvm/README.rst
@@ -6,7 +6,7 @@ virtual images for Linux Kernel-based Virtual Machines. It supports the
 installation of `virtio kernel
 modules <http://www.linux-kvm.org/page/Virtio>`__ (paravirtualized
 drivers for IO operations).
-It also supports creating an image with LVM as a disk backend.
+It also supports creating an image with LVM and qcow2 as a disk backend.
 
 Manifest settings
 -----------------

--- a/bootstrapvz/providers/kvm/manifest-schema.yml
+++ b/bootstrapvz/providers/kvm/manifest-schema.yml
@@ -32,7 +32,8 @@ properties:
     properties:
       backing:
         type: string
-        enum: 
+        enum:
+        - qcow2
         - raw
         - lvm
       logicalvolume: {type: string}

--- a/manifests/README.rst
+++ b/manifests/README.rst
@@ -276,7 +276,7 @@ boot, root and swap.
 
 -  ``backing``: Specifies the volume backing. This setting is very
    provider specific.
-   Valid values: ``ebs``, ``s3``, ``vmdk``, ``vdi``, ``raw``
+   Valid values: ``ebs``, ``s3``, ``vmdk``, ``vdi``, ``raw``, ``qcow2``, ``lvm``
    ``required``
 -  ``partitions``: A map of the partitions that should be created on
    the volume.

--- a/manifests/examples/kvm/jessie-qcow2.yml
+++ b/manifests/examples/kvm/jessie-qcow2.yml
@@ -1,0 +1,24 @@
+---
+name: debian-qcow2-example
+provider:
+  name: kvm
+bootstrapper:
+  workspace: /target
+system:
+  release: jessie
+  architecture: amd64
+  bootloader: grub
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+  backing: qcow2
+  partitions:
+    type: gpt
+    root:
+      filesystem: ext4
+      size: 1GB
+packages: {}
+plugins:
+  root_password:
+    password: test


### PR DESCRIPTION
This enables building an image with qcow2 as a disk backend.
Qcow2 is only supported by KVM.

The update implements a new class that inherits from QEMUVolume and just
needs the extension and file format.

A manifest has been included for testing purposes.