### PR TITLE
minimize_size: make sure the permissions of bindmounts are preserved

### DIFF
--- a/bootstrapvz/plugins/minimize_size/tasks/mounts.py
+++ b/bootstrapvz/plugins/minimize_size/tasks/mounts.py
@@ -21,6 +21,7 @@ class AddFolderMounts(Task):
             os.mkdir(temp_path)
 
             full_path = os.path.join(info.root, folder)
+            os.chmod(temp_path, os.stat(full_path).st_mode)
             info.volume.partition_map.root.add_mount(temp_path, full_path, ['--bind'])
 
 


### PR DESCRIPTION
I am getting the following errors when using the `minimize_size` plugin:

```
[…]
Mounting folders for writing temporary and cache data
Writing aptitude sources to disk
Generating system locale
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
LANGUAGE = (unset),
LC_ALL = (unset),
LANG = "pl_PL.utf8"
are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
Disabling daemon autostart
Updating the package cache
W: GPG error: http://security.debian.org stretch/updates InRelease: Couldn't create temporary file /tmp/apt.conf.kQin5D for passing config to apt-key
W: The repository 'http://security.debian.org stretch/updates InRelease' is not signed.
W: GPG error: http://deb.debian.org/debian stretch-updates InRelease: Couldn't create temporary file /tmp/apt.conf.kvlBvG for passing config to apt-key
W: The repository 'http://deb.debian.org/debian stretch-updates InRelease' is not signed.
W: GPG error: http://deb.debian.org/debian stretch Release: Couldn't create temporary file /tmp/apt.conf.VYQlGQ for passing config to apt-key
W: The repository 'http://deb.debian.org/debian stretch Release' is not signed.
Upgrading packages and fixing broken dependencies
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
apt exited with status code 100. This can sometimes occur when package retrieval times out or a package extraction failed. apt might succeed if you try bootstrapping again.
Command 'chroot […]/workspace/31a2f626/root apt-get upgrade --no-install-recommends --assume-yes' returned non-zero exit status 100
Traceback (most recent call last):
  File "[…]/bootstrap-vz/bootstrapvz/base/main.py", line 111, in run
    tasklist.run(info=bootstrap_info, dry_run=dry_run)
  File "[…]/bootstrap-vz/bootstrapvz/base/tasklist.py", line 44, in run
    task.run(info)
  File "[…]/bootstrap-vz/bootstrapvz/common/tasks/apt.py", line 217, in run
    '--assume-yes'])
  File "[…]/bootstrap-vz/bootstrapvz/common/tools.py", line 13, in log_check_call
    raise e
CalledProcessError: Command 'chroot […]/workspace/31a2f626/root apt-get upgrade --no-install-recommends --assume-yes' returned non-zero exit status 100
Rolling back
[…]
```

I tracked it down to possibly incorrect permissions set on `/tmp` inside the chroot environment. It turns out that before the `Mounting folders for writing temporary and cache data` task, `/tmp` has permissions of `1777`. However, the task in line `bootstrapvz/plugins/minimize_size/tasks/mounts.py:21` creates a new temporary directory with default permissions of `0755` and then bind-mounts it on top of the proper `/tmp`. This in turn stops `apt` from working correctly: for tasks of managing the package cache, `apt` drops privileges by changing to the `_apt` user, which no longer can write to `/tmp`.

The attached patch resolves the problem by ensuring that `minimize_size` bind-mountpoints have the same permissions as the original directories.