### PR TITLE
brief note about escaping braces in manifests

### DIFF
--- a/manifests/README.rst
+++ b/manifests/README.rst
@@ -21,6 +21,10 @@ setting. Not all settings support this though, to see whether embedding
 a manifest variable in a setting is possible, look for the
 ``manifest vars`` label.
 
+To insert a literal ``{foo}``, eg. in a shell command where you may want
+to use the expression ``${foo}``, use double braces instead, ie.
+``{{foo}}``.
+
 Sections
 --------
 

--- a/manifests/README.rst
+++ b/manifests/README.rst
@@ -21,9 +21,9 @@ setting. Not all settings support this though, to see whether embedding
 a manifest variable in a setting is possible, look for the
 ``manifest vars`` label.
 
-To insert a literal ``{foo}``, eg. in a shell command where you may want
-to use the expression ``${foo}``, use double braces instead, ie.
-``{{foo}}``.
+To insert a literal ``{foo}`` use double braces, that is ``{{foo}}``.
+For example in a shell command where you may want to use the
+expression ``${foo}``, use ``${{foo}}`` instead.
 
 Sections
 --------


### PR DESCRIPTION
as mentioned in #389 ... `{{foo}}` is indeed the thing to do 👍 