### PR TITLE
Puppet tasks fix commit

### DIFF
--- a/bootstrapvz/plugins/puppet/tasks.py
+++ b/bootstrapvz/plugins/puppet/tasks.py
@@ -1,6 +1,7 @@
 import os
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
+from bootstrapvz.common.tasks import apt
 from bootstrapvz.common.exceptions import TaskError
 from bootstrapvz.common.releases import jessie, wheezy
 from bootstrapvz.common.tools import sed_i, log_check_call, rel_path
@@ -59,6 +60,7 @@ class CheckManifestPath(Task):
 class InstallPuppetlabsPC1ReleaseKey(Task):
     description = 'Install puppetlabs PC1 Release key into the keyring'
     phase = phases.package_installation
+    successors = [apt.WriteSources]
 
     @classmethod
     def run(cls, info):


### PR DESCRIPTION
* fixed an issue where apt sources get written before the 
  InstallPuppetlabsPC1ReleaseKey task is performed. added a successor
  to the task.
* tox is green