### PR TITLE
Update Google Compute Engine package and repository structure.

### DIFF
--- a/manifests/official/gce/README.rst
+++ b/manifests/official/gce/README.rst
@@ -6,24 +6,22 @@ These are the official manifests used to build [Google Compute Engine (GCE) Debi
 The included packages and configuration changes are necessary for Debian to run on GCE as a first class citizen of the platform.
 Included GCE software is published on github: [Google Compute Engine guest environment](https://github.com/GoogleCloudPlatform/compute-image-packages)
 
-Debian 8 Jessie Package Notes:
+Debian 8 Package Notes:
 
 * python-crcmod is pulled in from backports as it provides a compiled crcmod required for the Google Cloud Storage CLI (gsutil).
 * cloud-utils and cloud-guest-utils are pulled in from backports as they provide a fixed version of growpart to safely grow the root partition on disks >2TB.
+
+Debian 8 and 9 Package Notes:
+
 * google-cloud-sdk is pulled from a Google Cloud repository.
 * google-compute-engine is pulled from a Google Cloud repository.
-* google-compute-engine-init is pulled from a Google Cloud repository.
-* google-config is pulled from a Google Cloud repository.
+* python-google-compute-engine is pulled from a Google Cloud repository.
+* python3-google-compute-engine is pulled from a Google Cloud repository.
 
-jessie-minimal:
+jessie-minimal and stretch-minimal:
 
-The only additions are the necessary google-compute-engine, google-compute-engine-init, and google-config packages. This image is not published on GCE however the manifest is provided here for those wishing a minimal GCE Debian image.
-
-stretch and stretch-minimal:
-
-These manifests are provided for testing. Debian 9 Stretch is not yet stable.
+The only additions are the necessary google-compute-engine, python-google-compute-engine, and python3-google-compute-engine packages. This image is not published on GCE however the manifest is provided here for those wishing a minimal GCE Debian image.
 
 Deprecated manifests:
 
-Debian 7 Wheezy and Backports Debian 7 Wheezy are deprecated images on GCE and are no longer supported.
-These manifests are provided here for historic purposes.
+Debian 7 Wheezy and Backports Debian 7 Wheezy are deprecated images on GCE and are no longer supported. These manifests are provided here for historic purposes.

--- a/manifests/official/gce/jessie-minimal.yml
+++ b/manifests/official/gce/jessie-minimal.yml
@@ -23,11 +23,11 @@ packages:
   include-source-type: true
   sources:
     google-cloud:
-      - deb http://packages.cloud.google.com/apt google-cloud-compute-{system.release} main
+      - deb http://packages.cloud.google.com/apt google-compute-engine-{system.release}-stable main
   install:
-    - google-compute-engine-{system.release}
-    - google-compute-engine-init-{system.release}
-    - google-config-{system.release}
+    - google-compute-engine
+    - python-google-compute-engine
+    - python3-google-compute-engine
 plugins:
   google_cloud_repo:
     cleanup_bootstrap_key: true

--- a/manifests/official/gce/jessie.yml
+++ b/manifests/official/gce/jessie.yml
@@ -24,13 +24,13 @@ packages:
   sources:
     google-cloud:
       - deb http://packages.cloud.google.com/apt cloud-sdk-{system.release} main
-      - deb http://packages.cloud.google.com/apt google-cloud-compute-{system.release} main
+      - deb http://packages.cloud.google.com/apt google-compute-engine-{system.release}-stable main
   install:
     - file
     - google-cloud-sdk
-    - google-compute-engine-{system.release}
-    - google-compute-engine-init-{system.release}
-    - google-config-{system.release}
+    - google-compute-engine
+    - python-google-compute-engine
+    - python3-google-compute-engine
     - python-crcmod
     - screen
     - vim

--- a/manifests/official/gce/stretch-minimal.yml
+++ b/manifests/official/gce/stretch-minimal.yml
@@ -23,11 +23,11 @@ packages:
   include-source-type: true
   sources:
     google-cloud:
-      - deb http://packages.cloud.google.com/apt google-cloud-compute-{system.release} main
+      - deb http://packages.cloud.google.com/apt google-compute-engine-{system.release}-stable main
   install:
-    - google-compute-engine-{system.release}
-    - google-compute-engine-init-{system.release}
-    - google-config-{system.release}
+    - google-compute-engine
+    - python-google-compute-engine
+    - python3-google-compute-engine
 plugins:
   google_cloud_repo:
     cleanup_bootstrap_key: true

--- a/manifests/official/gce/stretch.yml
+++ b/manifests/official/gce/stretch.yml
@@ -24,13 +24,13 @@ packages:
   sources:
     google-cloud:
       - deb http://packages.cloud.google.com/apt cloud-sdk-{system.release} main
-      - deb http://packages.cloud.google.com/apt google-cloud-compute-{system.release} main
+      - deb http://packages.cloud.google.com/apt google-compute-engine-{system.release}-stable main
   install:
     - file
     - google-cloud-sdk
-    - google-compute-engine-{system.release}
-    - google-compute-engine-init-{system.release}
-    - google-config-{system.release}
+    - google-compute-engine
+    - python-google-compute-engine
+    - python3-google-compute-engine
     - man
     - net-tools
     - python-crcmod


### PR DESCRIPTION
GCE packages are now Debian policy compliant and therefore we have new package names and repositories.