### PR TITLE
Instance store AMIs with HVM virtualization

### DIFF
--- a/bootstrapvz/providers/ec2/__init__.py
+++ b/bootstrapvz/providers/ec2/__init__.py
@@ -31,18 +31,10 @@ def validate_manifest(data, validator, error):
 
     bootloader = data['system']['bootloader']
     virtualization = data['provider']['virtualization']
-    backing = data['volume']['backing']
-    partition_type = data['volume']['partitions']['type']
     enhanced_networking = data['provider']['enhanced_networking'] if 'enhanced_networking' in data['provider'] else None
 
     if virtualization == 'pvm' and bootloader != 'pvgrub':
         error('Paravirtualized AMIs only support pvgrub as a bootloader', ['system', 'bootloader'])
-
-    if backing != 'ebs' and virtualization == 'hvm':
-            error('HVM AMIs currently only work when they are EBS backed', ['volume', 'backing'])
-
-    if backing == 's3' and partition_type != 'none':
-            error('S3 backed AMIs currently only work with unpartitioned volumes', ['system', 'bootloader'])
 
     if enhanced_networking == 'simple' and virtualization != 'hvm':
             error('Enhanced networking only works with HVM virtualization', ['provider', 'virtualization'])

--- a/manifests/examples/ec2/s3-jessie-amd64-hvm-us-east-1.yml
+++ b/manifests/examples/ec2/s3-jessie-amd64-hvm-us-east-1.yml
@@ -1,0 +1,63 @@
+---
+name: debian-{system.release}-{system.architecture}-{provider.virtualization}-{%Y}-{%m}-{%d}-{%H}{%M}-s3
+tags:
+  Name: "Jessie 8.9+1"
+  Debian: "8.9~{%Y}{%m}{%d}{%H}{%M}"
+provider:
+  name: ec2
+  virtualization: hvm
+  enhanced_networking: simple
+  # credentials:
+  #   access-key: AFAKEACCESSKEYFORAWS
+  #   secret-key: thes3cr3tkeyf0ryourawsaccount/FS4d8Qdva
+  #   certificate: /path/to/certificate
+  #   private-key: /path/to/private.key
+  #   user-id: your-aws-user-id
+  description: Debian {system.release} {system.architecture}
+  region: us-east-1
+  bucket: myamis-us-east-1
+bootstrapper:
+  workspace: /target
+system:
+  release: jessie
+  architecture: amd64
+  bootloader: grub
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+  backing: s3
+  partitions:
+    type: msdos
+    root:
+      filesystem: ext4
+      size: 8GiB
+packages:
+  mirror: http://cloudfront.debian.net/debian
+  components:
+    - main
+    - contrib
+    - non-free
+  preferences:
+    backport-cloud-init-cloud-utils:
+      - package: cloud-init cloud-utils
+        pin: release n=jessie-backports
+        pin-priority: 500
+  install:
+    - awscli
+    - python-boto
+    - python3-boto
+    - apt-transport-https
+    - ncurses-term
+    - cloud-init
+    - cloud-utils
+    - systemd
+    - systemd-sysv
+plugins:
+  ntp: {}
+  cloud_init:
+    username: admin
+  unattended_upgrades:
+    update_interval: 1
+    download_interval: 1
+    upgrade_interval: 1

--- a/manifests/examples/ec2/s3-stretch-amd64-hvm-us-east-1.yml
+++ b/manifests/examples/ec2/s3-stretch-amd64-hvm-us-east-1.yml
@@ -1,0 +1,58 @@
+---
+name: debian-{system.release}-{system.architecture}-{provider.virtualization}-{%Y}-{%m}-{%d}-{%H}{%M}-s3
+tags:
+  Name: "Stretch 9.1+1"
+  Debian: "9.1~{%Y}{%m}{%d}{%H}{%M}"
+provider:
+  name: ec2
+  virtualization: hvm
+  enhanced_networking: simple
+  # credentials:
+  #   access-key: AFAKEACCESSKEYFORAWS
+  #   secret-key: thes3cr3tkeyf0ryourawsaccount/FS4d8Qdva
+  #   certificate: /path/to/certificate
+  #   private-key: /path/to/private.key
+  #   user-id: your-aws-user-id
+  description: Debian {system.release} {system.architecture}
+  region: us-east-1
+  bucket: myamis-us-east-1
+bootstrapper:
+  workspace: /target
+system:
+  release: stretch
+  architecture: amd64
+  bootloader: grub
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+  backing: s3
+  partitions:
+    type: msdos
+    root:
+      filesystem: ext4
+      size: 8GiB
+packages:
+  mirror: http://cloudfront.debian.net/debian
+  components:
+    - main
+    - contrib
+    - non-free
+  install:
+    - awscli
+    - python-boto
+    - python3-boto
+    - apt-transport-https
+    - ncurses-term
+    - cloud-init
+    - cloud-utils
+    - systemd
+    - systemd-sysv
+plugins:
+  ntp: {}
+  cloud_init:
+    username: admin
+  unattended_upgrades:
+    update_interval: 1
+    download_interval: 1
+    upgrade_interval: 1


### PR DESCRIPTION
I've been able to:

1. build instance store AMIs with HVM virtualization
2. launch instances successfully
3. test them without any issue

just by allowing such a setup in the code and by using these two manifests.

If you plan to support such a (instance type / virtualization) couple in the future, feel free to review and decide the fate of this PR 😬

