### PR TITLE
#397 fix: Installing networking kernel driver using DKMS fails in stretch

### DIFF
--- a/bootstrapvz/providers/ec2/tasks/network.py
+++ b/bootstrapvz/providers/ec2/tasks/network.py
@@ -87,8 +87,13 @@ class InstallEnhancedNetworking(Task):
 
     @classmethod
     def run(cls, info):
-        version = '3.2.2'
-        drivers_url = 'https://downloadmirror.intel.com/26561/eng/ixgbevf-3.2.2.tar.gz'
+        from bootstrapvz.common.releases import stretch
+        if info.manifest.release >= stretch:
+            version = '4.2.1'
+            drivers_url = 'https://downloadmirror.intel.com/18700/eng/ixgbevf-4.2.1.tar.gz'
+        else:
+            version = '3.2.2'
+            drivers_url = 'https://downloadmirror.intel.com/26561/eng/ixgbevf-3.2.2.tar.gz'
         # Sadly the first number in the URL changes:
         # 2.16.1 => https://downloadmirror.intel.com/25464/eng/ixgbevf-2.16.1.tar.gz
         archive = os.path.join(info.root, 'tmp', 'ixgbevf-%s.tar.gz' % (version))


### PR DESCRIPTION
Apply new version when release is stretch or higher.