### PR TITLE
allow networking task when netbase pkg is present

### DIFF
--- a/bootstrapvz/common/task_groups.py
+++ b/bootstrapvz/common/task_groups.py
@@ -96,7 +96,10 @@ ssh_group = [ssh.AddOpenSSHPackage,
 
 
 def get_network_group(manifest):
-    if manifest.bootstrapper.get('variant', None) == 'minbase':
+    if (
+       manifest.bootstrapper.get('variant', None) == 'minbase' and
+       'netbase' not in manifest.bootstrapper.get('include_packages', [])
+       ):
         # minbase has no networking
         return []
     group = [network.ConfigureNetworkIF,


### PR DESCRIPTION
Currently if the variant minbase is used, the network task is skipped. But if the netbase package is installed, the network should be configured.