### PR TITLE
Add password-crypt to root password plugin

### DIFF
--- a/bootstrapvz/plugins/root_password/README.rst
+++ b/bootstrapvz/plugins/root_password/README.rst
@@ -6,6 +6,15 @@ SSH password authentication.
 
 Settings
 ~~~~~~~~
+``oneOf``
 
 -  ``password``: The password for the root user.
-   ``required``
+-  ``password-crypted``: The password for the root user[crypt(3) hash]
+
+The following command (available from the **whois** package) can be used
+to generate a SHA-512 based crypt(3) hash for a password:
+
+.. code-block:: shell
+
+  mkpasswd -m sha-512
+

--- a/bootstrapvz/plugins/root_password/manifest-schema.yml
+++ b/bootstrapvz/plugins/root_password/manifest-schema.yml
@@ -8,7 +8,11 @@ properties:
     properties:
       root_password:
         type: object
+        oneOf:
+          - required: [password]
+          - required: [password-crypted]
         properties:
           password: {type: string}
-        required: [password]
+        properties:
+          password-crypted: {type: string}
         additionalProperties: false

--- a/bootstrapvz/plugins/root_password/manifest-schema.yml
+++ b/bootstrapvz/plugins/root_password/manifest-schema.yml
@@ -13,6 +13,5 @@ properties:
           - required: [password-crypted]
         properties:
           password: {type: string}
-        properties:
           password-crypted: {type: string}
         additionalProperties: false

--- a/bootstrapvz/plugins/root_password/tasks.py
+++ b/bootstrapvz/plugins/root_password/tasks.py
@@ -9,5 +9,11 @@ class SetRootPassword(Task):
     @classmethod
     def run(cls, info):
         from bootstrapvz.common.tools import log_check_call
-        log_check_call(['chroot', info.root, 'chpasswd'],
-                       'root:' + info.manifest.plugins['root_password']['password'])
+        password_crypted = info.manifest.plugins['root_password'].get('password-crypted', None)
+        if password_crypted is not None:
+            log_check_call(['chpasswd', '--root', info.root, '--encrypted'],
+                           'root:' + password_crypted)
+        else:
+            log_check_call(['chroot', info.root, 'chpasswd'],
+                           'root:' + info.manifest.plugins['root_password']['password'])
+

--- a/bootstrapvz/plugins/root_password/tasks.py
+++ b/bootstrapvz/plugins/root_password/tasks.py
@@ -11,9 +11,8 @@ class SetRootPassword(Task):
         from bootstrapvz.common.tools import log_check_call
         password_crypted = info.manifest.plugins['root_password'].get('password-crypted', None)
         if password_crypted is not None:
-            log_check_call(['chpasswd', '--root', info.root, '--encrypted'],
+            log_check_call(['chroot', info.root, '/usr/sbin/chpasswd', '--encrypted'],
                            'root:' + password_crypted)
         else:
-            log_check_call(['chroot', info.root, 'chpasswd'],
+            log_check_call(['chroot', info.root, '/usr/sbin/chpasswd'],
                            'root:' + info.manifest.plugins['root_password']['password'])
-

--- a/manifests/examples/virtualbox/stretch-vagrant.yml
+++ b/manifests/examples/virtualbox/stretch-vagrant.yml
@@ -28,3 +28,5 @@ volume:
 packages: {}
 plugins:
   vagrant: {}
+  root_password:
+    password-crypted: $6$MU3jLtZHS$UHdibqwOJrZw5yI7cqzG.AnzWqOVD9krryd3Y/SgXDSHUEMsaT7iAiQHhuCpjN4Q0tEssbJYoy4H1QFxOY3Tc/


### PR DESCRIPTION
Added an option to the root_password plugin to use a password hash.

- Added password-crypted to root_password plugin.
- Updated the docs for root_password plugin
- Added password-crypted to example manifest for stretch vagrant