### PR TITLE
Remove ED25519 ssh host key pair from image

### DIFF
--- a/bootstrapvz/common/assets/init.d/jessie/generate-ssh-hostkeys
+++ b/bootstrapvz/common/assets/init.d/jessie/generate-ssh-hostkeys
@@ -5,7 +5,7 @@
 # Required-Stop:  
 # Should-Start:   
 # Should-Stop:    
-# Default-Start:  2 3 4 5
+# Default-Start:  S
 # Default-Stop:   
 # Description:    Generate ssh host keys if they do not exist
 ### END INIT INFO
@@ -14,16 +14,18 @@ prog=$(basename $0)
 logger="logger -t $prog"
 
 rsa_key="/etc/ssh/ssh_host_rsa_key"
+dsa_key="/etc/ssh/ssh_host_dsa_key"
 ecdsa_key="/etc/ssh/ssh_host_ecdsa_key"
 ed25519_key="/etc/ssh/ssh_host_ed25519_key"
 
 # Exit if the hostkeys already exist
-if [ -f $rsa_key -a -f $ecdsa_key -a -f $ed25519_key ]; then
+if [ -f $rsa_key -a -f $dsa_key -a -f $ecdsa_key -a -f $ed25519_key ]; then
 	exit
 fi
 
 # Generate the ssh host keys
 [ -f $rsa_key ] || ssh-keygen -f $rsa_key -t rsa -C 'host' -N ''
+[ -f $dsa_key ] || ssh-keygen -f $dsa_key -t dsa -C 'host' -N ''
 [ -f $ecdsa_key ] || ssh-keygen -f $ecdsa_key -t ecdsa -C 'host' -N ''
 [ -f $ed25519_key ] || ssh-keygen -f $ed25519_key -t ed25519 -C 'host' -N ''
 
@@ -31,6 +33,7 @@ fi
 # This allows user to get host keys securely through console log
 echo "-----BEGIN SSH HOST KEY FINGERPRINTS-----" | $logger
 ssh-keygen -l -f $rsa_key.pub | $logger
+ssh-keygen -l -f $dsa_key.pub | $logger
 ssh-keygen -l -f $ecdsa_key.pub | $logger
 ssh-keygen -l -f $ed25519_key.pub | $logger
 echo "------END SSH HOST KEY FINGERPRINTS------" | $logger

--- a/bootstrapvz/common/assets/init.d/wheezy/generate-ssh-hostkeys
+++ b/bootstrapvz/common/assets/init.d/wheezy/generate-ssh-hostkeys
@@ -5,7 +5,7 @@
 # Required-Stop:  
 # Should-Start:   
 # Should-Stop:    
-# Default-Start:  2 3 4 5
+# Default-Start:  S
 # Default-Stop:   
 # Description:    Generate ssh host keys if they do not exist
 ### END INIT INFO
@@ -14,23 +14,23 @@ prog=$(basename $0)
 logger="logger -t $prog"
 
 rsa_key="/etc/ssh/ssh_host_rsa_key"
+dsa_key="/etc/ssh/ssh_host_dsa_key"
 ecdsa_key="/etc/ssh/ssh_host_ecdsa_key"
-ed25519_key="/etc/ssh/ssh_host_ed25519_key"
 
 # Exit if the hostkeys already exist
-if [ -f $rsa_key -a -f $ecdsa_key -a -f $ed25519_key ]; then
+if [ -f $rsa_key -a -f $dsa_key -a -f $ecdsa_key ]; then
 	exit
 fi
 
 # Generate the ssh host keys
 [ -f $rsa_key ] || ssh-keygen -f $rsa_key -t rsa -C 'host' -N ''
+[ -f $dsa_key ] || ssh-keygen -f $dsa_key -t dsa -C 'host' -N ''
 [ -f $ecdsa_key ] || ssh-keygen -f $ecdsa_key -t ecdsa -C 'host' -N ''
-[ -f $ed25519_key ] || ssh-keygen -f $ed25519_key -t ed25519 -C 'host' -N ''
 
 # Output the public keys to the console
 # This allows user to get host keys securely through console log
 echo "-----BEGIN SSH HOST KEY FINGERPRINTS-----" | $logger
 ssh-keygen -l -f $rsa_key.pub | $logger
+ssh-keygen -l -f $dsa_key.pub | $logger
 ssh-keygen -l -f $ecdsa_key.pub | $logger
-ssh-keygen -l -f $ed25519_key.pub | $logger
 echo "------END SSH HOST KEY FINGERPRINTS------" | $logger

--- a/bootstrapvz/common/tasks/ssh.py
+++ b/bootstrapvz/common/tasks/ssh.py
@@ -29,8 +29,14 @@ class AddSSHKeyGeneration(Task):
             log_check_call(['chroot', info.root,
                             'dpkg-query', '-W', 'openssh-server'])
             from bootstrapvz.common.releases import squeeze
+            from bootstrapvz.common.releases import wheezy
+            from bootstrapvz.common.releases import jessie
             if info.manifest.release == squeeze:
                 install['generate-ssh-hostkeys'] = os.path.join(init_scripts_dir, 'squeeze/generate-ssh-hostkeys')
+            elif info.manifest.release == wheezy:
+                install['generate-ssh-hostkeys'] = os.path.join(init_scripts_dir, 'wheezy/generate-ssh-hostkeys')
+            elif info.manifest.release == jessie:
+                install['generate-ssh-hostkeys'] = os.path.join(init_scripts_dir, 'jessie/generate-ssh-hostkeys')
             else:
                 install['generate-ssh-hostkeys'] = os.path.join(init_scripts_dir, 'generate-ssh-hostkeys')
         except CalledProcessError:
@@ -105,6 +111,10 @@ class ShredHostkeys(Task):
         from bootstrapvz.common.releases import wheezy
         if info.manifest.release >= wheezy:
             ssh_hostkeys.append('ssh_host_ecdsa_key')
+
+        from bootstrapvz.common.releases import jessie
+        if info.manifest.release >= jessie:
+            ssh_hostkeys.append('ssh_host_ed25519_key')
 
         private = [os.path.join(info.root, 'etc/ssh', name) for name in ssh_hostkeys]
         public = [path + '.pub' for path in private]


### PR DESCRIPTION
ED25519 ssh host key pair is not removed from ```/etc/ssh```:

```
$ ls -l /etc/ssh/ssh_host_*
-rw------- 1 root root 399 Jan  8 16:39 etc/ssh/ssh_host_ed25519_key
-rw-r--r-- 1 root root  94 Jan  8 16:39 etc/ssh/ssh_host_ed25519_key.pub
```

ED25519 ssh key pair is created since OpenSSH 6.5 (6.7 in Debian jessie) https://wiki.debian.org/SSH#Installation_of_the_server