### PR TITLE
Change location of expand-root systemd unit from /lib/... to /etc/...

### DIFF
--- a/bootstrapvz/plugins/expand_root/tasks.py
+++ b/bootstrapvz/plugins/expand_root/tasks.py
@@ -38,7 +38,7 @@ class InstallExpandRootScripts(Task):
         expand_root_service = os.path.join(ASSETS_DIR, 'expand-root.service')
 
         expand_root_script_dest = os.path.join(info.root, 'usr/bin/expand-root.sh')
-        expand_root_service_dest = os.path.join(info.root, 'lib/systemd/system/expand-root.service')
+        expand_root_service_dest = os.path.join(info.root, 'etc/systemd/system/expand-root.service')
 
         filesystem_type = info.manifest.plugins['expand_root'].get('filesystem_type')
         root_device = info.manifest.plugins['expand_root'].get('root_device')


### PR DESCRIPTION
Change location of expand-root systemd unit from ```/lib/systemd/system``` to ```/etc/systemd/system```.

System administrators should put customized unit files in ```/etc/systemd/system``` and ```/lib/systemd/system``` should contain units provided by installed packages (deb).

https://www.freedesktop.org/software/systemd/man/systemd.unit.html and https://wiki.debian.org/systemd