### PR TITLE
tmpfs_workspace: Plugin for having workspace on tmpfs for speed

### DIFF
--- a/bootstrapvz/plugins/tmpfs_workspace/README.rst
+++ b/bootstrapvz/plugins/tmpfs_workspace/README.rst
@@ -1,0 +1,18 @@
+tmpfs workspace
+---------------
+
+The ``tmpfs workspace`` plugin mounts a tmpfs filesystem for the
+workspace temporary files. This is useful when the workspace directory
+is placed on a slow medium (e.g. a hard disk drive), the build process
+performs lots of local I/O (e.g. building a vagrant box), and there is
+enough RAM to store data necessary for the build process. For example,
+the ``stretch-vagrant.yml`` manifest file from the examples directory
+takes 33 minutes to build on the plugin author's home server. Using
+this plugin reduces this time to 3 minutes at the cost of 1.2GB of
+additional RAM usage.
+
+Settings
+~~~~~~~~
+
+This plugin has no settings. To enable it add ``"tmpfs_workspace":{}``
+to the plugin section of the manifest.

--- a/bootstrapvz/plugins/tmpfs_workspace/__init__.py
+++ b/bootstrapvz/plugins/tmpfs_workspace/__init__.py
@@ -1,0 +1,17 @@
+from bootstrapvz.common.tasks.workspace import CreateWorkspace, DeleteWorkspace
+from tasks import CreateTmpFsWorkspace, MountTmpFsWorkspace, UnmountTmpFsWorkspace, DeleteTmpFsWorkspace
+
+
+def resolve_tasks(taskset, manifest):
+    taskset.discard(CreateWorkspace)
+    taskset.discard(DeleteWorkspace)
+
+    taskset.add(CreateTmpFsWorkspace)
+    taskset.add(MountTmpFsWorkspace)
+    taskset.add(UnmountTmpFsWorkspace)
+    taskset.add(DeleteTmpFsWorkspace)
+
+
+def resolve_rollback_tasks(taskset, manifest, completed, counter_task):
+    counter_task(taskset, MountTmpFsWorkspace, UnmountTmpFsWorkspace)
+    counter_task(taskset, CreateTmpFsWorkspace, DeleteTmpFsWorkspace)

--- a/bootstrapvz/plugins/tmpfs_workspace/tasks.py
+++ b/bootstrapvz/plugins/tmpfs_workspace/tasks.py
@@ -1,0 +1,50 @@
+from os import makedirs, rmdir
+
+from bootstrapvz.base import Task
+from bootstrapvz.common.tasks.workspace import CreateWorkspace, DeleteWorkspace
+from bootstrapvz.common import phases
+from bootstrapvz.common.tools import log_check_call
+
+
+class CreateTmpFsWorkspace(Task):
+    description = 'Creating directory for tmpfs-based workspace'
+    phase = phases.preparation
+
+    @classmethod
+    def run(cls, info):
+        makedirs(info.workspace)
+
+
+class MountTmpFsWorkspace(Task):
+    description = 'Mounting tmpfs-based workspace'
+    phase = phases.preparation
+
+    # CreateWorkspace is explicitly skipped (see the plugin's resolve_task function). Several other tasks
+    # depend on CreateWorkspace to put their own files inside the workspace. We position MountTmpFs before
+    # CreateWorkspace to leverage these dependencies. See also UnmountTmpFs/DeleteWorkspace below.
+    successors = [CreateWorkspace]
+    predecessors = [CreateTmpFsWorkspace]
+
+    @classmethod
+    def run(cls, info):
+        log_check_call(['mount', '--types', 'tmpfs', 'none', info.workspace])
+
+
+class UnmountTmpFsWorkspace(Task):
+    description = 'Unmounting tmpfs-based workspace'
+    phase = phases.cleaning
+    predecessors = [DeleteWorkspace]
+
+    @classmethod
+    def run(cls, info):
+        log_check_call(['umount', info.workspace])
+
+
+class DeleteTmpFsWorkspace(Task):
+    description = 'Deleting directory for tmpfs-based workspace'
+    phase = phases.cleaning
+    predecessors = [UnmountTmpFsWorkspace]
+
+    @classmethod
+    def run(cls, info):
+        rmdir(info.workspace)


### PR DESCRIPTION
A proof-of-concept with no documentation yet, for discussion.

I noticed that a full image build for one of my images takes about an hour on my home server with no SSD, but more than enough RAM. Tried mounting `tmpfs` over the workspace directory, and I started getting builds in 3 minutes. The idea sounds generic enough for other people to also benefit, so I wrote a plugin.

I should probably split the `MountTmpfs` task into two, to allow proper clean-up if `makedirs` succeeds, but `mount` fails.

I'd prefer not having an additional directory for `CreateWorkspace` to run, but I didn't find any good way to do so. I cannot replace/delete `CreateWorkspace` from a plugin. My first thought was to make `MountTmpfs` run after `CreateWorkspace` and simply mount `tmpfs` over the directory created by `CreateWorkspace`, but the dependency structure is such that I couldn't make `MountTmpfs` a successor of `CreateWorkspace`, nor `UnmountTmpfs` a predecessor of `DeleteWorkspace`, without explicitly listing all tasks from the `preparation`/`cleanup` phases that still perform some I/O inside the workspace directory. And listing them explicitly seems error-prone. So I decided to let `CreateWorkspace` do its thing on some directory that's already on tmpfs. Is there a better way?

If the current approach is fine, I'll write some documentation, split `MountTmpfs` and submit a more polished commit.