### PR TITLE
Minor changes to GRUB configuration regarding console and serial console

### DIFF
--- a/bootstrapvz/common/tasks/grub.py
+++ b/bootstrapvz/common/tasks/grub.py
@@ -238,7 +238,7 @@ class SetGrubTerminalToConsole(Task):
     @classmethod
     def run(cls, info):
         # See issue #245 for more details
-        info.grub_config['TERMINAL'] = 'console'
+        info.grub_config['GRUB_TERMINAL'] = 'console'
 
 
 class SetGrubConsolOutputDeviceToSerial(Task):
@@ -249,7 +249,8 @@ class SetGrubConsolOutputDeviceToSerial(Task):
     @classmethod
     def run(cls, info):
         # See issue #245 for more details
-        info.grub_config['GRUB_CMDLINE_LINUX_DEFAULT'].append('console=ttyS0')
+        info.grub_config['GRUB_CMDLINE_LINUX'].append('console=ttyS0')
+        info.grub_config['GRUB_CMDLINE_LINUX'].append('earlyprintk=ttyS0')
 
 
 class RemoveGrubTimeout(Task):


### PR DESCRIPTION
Minor changes to GRUB configuration regarding virtual and serial consoles:
* Corrected GRUB key/variable.
* Print kernel log messages that precede the initialisation of the traditional console to a serial console.
* Add console settings to both - default and recovery GRUB options (```GRUB_CMDLINE_LINUX``` instead of ```GRUB_CMDLINE_LINUX_DEFAULT```).

Above changes do not influence GRUB configuration modifications made by providers (Azure, GCE, EC2, VirtualBox).

GRUB documentation https://www.gnu.org/software/grub/manual/grub/grub.html#Simple-configuration 

Kernel documentation https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/serial-console.rst
