### PR TITLE
Add yamllint linter to check manifests files

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 160

--- a/manifests/examples/azure/jessie.yml
+++ b/manifests/examples/azure/jessie.yml
@@ -23,10 +23,10 @@ volume:
       size: 10GiB
 packages:
   components:
-  - main
-  - contrib
-  - non-free
+    - main
+    - contrib
+    - non-free
 plugins:
   ntp:
     servers:
-    - time.windows.com
+      - time.windows.com

--- a/manifests/examples/azure/wheezy.yml
+++ b/manifests/examples/azure/wheezy.yml
@@ -23,15 +23,15 @@ volume:
       size: 10GiB
 packages:
   components:
-  - main
-  - contrib
-  - non-free
+    - main
+    - contrib
+    - non-free
   preferences:
     backport-kernel:
-    - package: linux-image-* initramfs-tools
-      pin: release n=wheezy-backports
-      pin-priority: 500
+      - package: linux-image-* initramfs-tools
+        pin: release n=wheezy-backports
+        pin-priority: 500
 plugins:
   ntp:
     servers:
-    - time.windows.com
+      - time.windows.com

--- a/manifests/examples/ec2/ebs-unstable-amd64-pvm-contrib.yml
+++ b/manifests/examples/ec2/ebs-unstable-amd64-pvm-contrib.yml
@@ -26,9 +26,9 @@ volume:
 packages:
   mirror: http://cloudfront.debian.net/debian
   components:
-  - main
-  - contrib
-  - non-free
+    - main
+    - contrib
+    - non-free
 plugins:
   cloud_init:
     metadata_sources: Ec2

--- a/manifests/examples/kvm/jessie-arm64-virtio.yml
+++ b/manifests/examples/kvm/jessie-arm64-virtio.yml
@@ -3,8 +3,8 @@ name: debian-{system.release}-{system.architecture}-{%y}{%m}{%d}
 provider:
   name: kvm
   virtio_modules:
-  - virtio_pci
-  - virtio_blk
+    - virtio_pci
+    - virtio_blk
 bootstrapper:
   workspace: /target
 system:

--- a/manifests/examples/kvm/jessie-puppet.yaml
+++ b/manifests/examples/kvm/jessie-puppet.yaml
@@ -3,8 +3,8 @@ name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
 provider:
   name: kvm
   virtio_modules:
-  - virtio_pci
-  - virtio_blk
+    - virtio_pci
+    - virtio_blk
 bootstrapper:
   workspace: /target
 system:
@@ -21,21 +21,21 @@ volume:
     root:
       filesystem: ext4
       size: 10GiB
-packages: 
+packages:
   install_standard: true
   mirror: http://httpredir.debian.org/debian
   install:
-    # required to be pre-installed for proper puppet functioning of 
-    #  puppetlabs-apt, it is also the primary puppet module
+    # required to be pre-installed for proper puppet functioning of
+    # puppetlabs-apt, it is also the primary puppet module
     - lsb-release
 plugins:
   # It is advisable to avoid running things as root, use a sudo account instead
   admin_user:
-    username: administrator 
+    username: administrator
     password: something
   # puppet plugin
   puppet:
-    # The assets path MUST be ABSOLUTE on your project. 
+    # The assets path MUST be ABSOLUTE on your project.
     assets: /your/absolute/path/to/etc/puppetlabs
     install_modules:
       - [puppetlabs-accounts]

--- a/manifests/examples/kvm/jessie-virtio.yml
+++ b/manifests/examples/kvm/jessie-virtio.yml
@@ -3,8 +3,8 @@ name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
 provider:
   name: kvm
   virtio_modules:
-  - virtio_pci
-  - virtio_blk
+    - virtio_pci
+    - virtio_blk
 bootstrapper:
   workspace: /target
 system:

--- a/manifests/examples/kvm/stretch-puppet.yaml
+++ b/manifests/examples/kvm/stretch-puppet.yaml
@@ -3,8 +3,8 @@ name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
 provider:
   name: kvm
   virtio_modules:
-  - virtio_pci
-  - virtio_blk
+    - virtio_pci
+    - virtio_blk
 bootstrapper:
   workspace: /target
 system:
@@ -21,21 +21,21 @@ volume:
     root:
       filesystem: ext4
       size: 10GiB
-packages: 
+packages:
   install_standard: true
   mirror: http://httpredir.debian.org/debian
   install:
-    # required to be pre-installed for proper puppet functioning of 
-    #  puppetlabs-apt, it is also the primary puppet module
+    # required to be pre-installed for proper puppet functioning of
+    # puppetlabs-apt, it is also the primary puppet module
     - lsb-release
 plugins:
   # It is advisable to avoid running things as root, use a sudo account instead
   admin_user:
-    username: administrator 
+    username: administrator
     password: something
   # puppet plugin
   puppet:
-    # The assets path MUST be ABSOLUTE on your project. 
+    # The assets path MUST be ABSOLUTE on your project.
     assets: /your/absolute/path/to/etc/puppetlabs
     install_modules:
       - [puppetlabs-accounts]

--- a/manifests/examples/kvm/stretch-virtio-partitions.yml
+++ b/manifests/examples/kvm/stretch-virtio-partitions.yml
@@ -3,8 +3,8 @@ name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
 provider:
   name: kvm
   virtio_modules:
-  - virtio_pci
-  - virtio_blk
+    - virtio_pci
+    - virtio_blk
 bootstrapper:
   workspace: /target
 system:

--- a/manifests/examples/kvm/wheezy-virtio.yml
+++ b/manifests/examples/kvm/wheezy-virtio.yml
@@ -3,8 +3,8 @@ name: debian-{system.release}-{system.architecture}-{%y}{%m}{%d}
 provider:
   name: kvm
   virtio_modules:
-  - virtio_pci
-  - virtio_blk
+    - virtio_pci
+    - virtio_blk
 bootstrapper:
   workspace: /target
 system:

--- a/manifests/official/ec2/s3-wheezy-amd64-pvm-cn-north-1.yml
+++ b/manifests/official/ec2/s3-wheezy-amd64-pvm-cn-north-1.yml
@@ -33,7 +33,7 @@ packages:
 plugins:
   cloud_init:
     disable_modules:
-    - landscape
-    - byobu
-    - ssh-import-id
+      - landscape
+      - byobu
+      - ssh-import-id
     username: admin

--- a/manifests/official/gce/buster-minimal.yml
+++ b/manifests/official/gce/buster-minimal.yml
@@ -34,4 +34,4 @@ plugins:
     enable_keyring_repo: true
   ntp:
     servers:
-    - metadata.google.internal
+      - metadata.google.internal

--- a/manifests/official/gce/buster.yml
+++ b/manifests/official/gce/buster.yml
@@ -46,7 +46,7 @@ plugins:
     enable_keyring_repo: true
   ntp:
     servers:
-    - metadata.google.internal
+      - metadata.google.internal
   unattended_upgrades:
     download_interval: 1
     update_interval: 1

--- a/manifests/official/gce/deprecated/wheezy-backports.yml
+++ b/manifests/official/gce/deprecated/wheezy-backports.yml
@@ -34,21 +34,21 @@ packages:
     - vim
   preferences:
     backport-kernel:
-    - package: linux-image-* initramfs-tools
-      pin: release n=wheezy-backports
-      pin-priority: 500
+      - package: linux-image-* initramfs-tools
+        pin: release n=wheezy-backports
+        pin-priority: 500
     backport-ssh:
-    - package: init-system-helpers openssh-sftp-server openssh-client openssh-server
-      pin: release n=wheezy-backports
-      pin-priority: 500
+      - package: init-system-helpers openssh-sftp-server openssh-client openssh-server
+        pin: release n=wheezy-backports
+        pin-priority: 500
     backport-growroot:
-    - package: cloud-initramfs-growroot
-      pin: release n=wheezy-backports
-      pin-priority: 500
+      - package: cloud-initramfs-growroot
+        pin: release n=wheezy-backports
+        pin-priority: 500
 plugins:
   google_cloud_repo:
-    cleanup_bootstrap_key: True
-    enable_keyring_repo: True
+    cleanup_bootstrap_key: true
+    enable_keyring_repo: true
   ntp:
     servers:
-    - metadata.google.internal
+      - metadata.google.internal

--- a/manifests/official/gce/deprecated/wheezy.yml
+++ b/manifests/official/gce/deprecated/wheezy.yml
@@ -34,8 +34,8 @@ packages:
     - vim
 plugins:
   google_cloud_repo:
-    cleanup_bootstrap_key: True
-    enable_keyring_repo: True
+    cleanup_bootstrap_key: true
+    enable_keyring_repo: true
   ntp:
     servers:
-    - metadata.google.internal
+      - metadata.google.internal

--- a/manifests/official/gce/jessie-minimal.yml
+++ b/manifests/official/gce/jessie-minimal.yml
@@ -34,4 +34,4 @@ plugins:
     enable_keyring_repo: true
   ntp:
     servers:
-    - metadata.google.internal
+      - metadata.google.internal

--- a/manifests/official/gce/jessie.yml
+++ b/manifests/official/gce/jessie.yml
@@ -37,9 +37,9 @@ packages:
   preferences:
     # python-crcmod in backports has a compiled version needed for Google Cloud Storage.
     backport-python-crcmod:
-    - package: python-crcmod
-      pin: release n=jessie-backports
-      pin-priority: 500
+      - package: python-crcmod
+        pin: release n=jessie-backports
+        pin-priority: 500
 plugins:
   expand_root:
     filesystem_type: ext4
@@ -50,7 +50,7 @@ plugins:
     enable_keyring_repo: true
   ntp:
     servers:
-    - metadata.google.internal
+      - metadata.google.internal
   unattended_upgrades:
     download_interval: 1
     update_interval: 1

--- a/manifests/official/gce/stretch-minimal.yml
+++ b/manifests/official/gce/stretch-minimal.yml
@@ -34,4 +34,4 @@ plugins:
     enable_keyring_repo: true
   ntp:
     servers:
-    - metadata.google.internal
+      - metadata.google.internal

--- a/manifests/official/gce/stretch.yml
+++ b/manifests/official/gce/stretch.yml
@@ -46,7 +46,7 @@ plugins:
     enable_keyring_repo: true
   ntp:
     servers:
-    - metadata.google.internal
+      - metadata.google.internal
   unattended_upgrades:
     download_interval: 1
     update_interval: 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, unit, integration, docs
+envlist = flake8, yamllint, unit, integration, docs
 
 [flake8]
 ignore = E221,E241,E501
@@ -38,3 +38,7 @@ deps =
     sphinx != 1.5
     sphinx_rtd_theme
 commands = sphinx-build -W -b html -d _build/html/doctrees . _build/html
+
+[testenv:yamllint]
+deps = yamllint
+commands = yamllint manifests


### PR DESCRIPTION
Add http://yamllint.readthedocs.io/ linter to check manifests files. 

I added yamllint environment to tox right after invoking flake8.

One nonadherence from default yamllint rules (```.yamllint```) is line length - changed from 80 to 160 characters. It's because lines that violate this rule are URLs and release names and I don't see a point in making it more complicated than it should be.
