### PR TITLE
Force order of tasks that add console=xxx to kernel command line (VirtualBox)

### DIFF
--- a/bootstrapvz/providers/virtualbox/tasks/boot.py
+++ b/bootstrapvz/providers/virtualbox/tasks/boot.py
@@ -6,6 +6,7 @@ from bootstrapvz.common.tasks import grub
 class AddVirtualConsoleGrubOutputDevice(Task):
     description = 'Adding `tty0\' as output device for grub'
     phase = phases.system_modification
+    predecessors = [grub.SetGrubConsolOutputDeviceToSerial]
     successors = [grub.WriteGrubConfig]
 
     @classmethod


### PR DESCRIPTION
Force order of tasks that add console=xxx to kernel command line (VirtualBox), as we discussed in https://github.com/andsens/bootstrap-vz/pull/436#issuecomment-359170266.