### PR TITLE
qemu-img also supports shrinking raw and qcow2 formats

### DIFF
--- a/bootstrapvz/plugins/minimize_size/README.rst
+++ b/bootstrapvz/plugins/minimize_size/README.rst
@@ -21,7 +21,7 @@ footprint:
       (only applicable when using vmdk backing). The tool is part of the
       `VMWare Workstation <https://my.vmware.com/web/vmware/info/slug/desktop_end_user_computing/vmware_workstation/10_0>`__
       package.
-   -  `qemu-img` (only applicaple when using vmdk or vdi backing). This
+   -  `qemu-img` (only applicaple when using vmdk, vdi, raw or qcow2 backing). This
       tool is part of the `QEMU emulator <https://www.qemu.org/>`__.
 
 -  Tell apt to only download specific language files. See the

--- a/bootstrapvz/plugins/minimize_size/__init__.py
+++ b/bootstrapvz/plugins/minimize_size/__init__.py
@@ -26,8 +26,8 @@ def validate_manifest(data, validator, error):
     shrink_type = get_shrink_type(data['plugins'])
     if shrink_type == 'vmware-vdiskmanager' and data['volume']['backing'] != 'vmdk':
         error('Can only shrink vmdk images with vmware-vdiskmanager', ['plugins', 'minimize_size', 'shrink'])
-    if shrink_type == 'qemu-img' and data['volume']['backing'] not in ('vmdk', 'vdi'):
-        error('Can only shrink vmdk and vdi images with qemu-img', ['plugins', 'minimize_size', 'shrink'])
+    if shrink_type == 'qemu-img' and data['volume']['backing'] not in ('vmdk', 'vdi', 'raw', 'qcow2'):
+        error('Can only shrink vmdk, vdi, raw and qcow2 images with qemu-img', ['plugins', 'minimize_size', 'shrink'])
 
 
 def resolve_tasks(taskset, manifest):


### PR DESCRIPTION
qemu-img also supports raw and qcow2 formats, so let's allow shrinking them too.

```
$ qemu-img --help | grep ^Supported
Supported formats: blkdebug blkreplay blkverify bochs cloop dmg file ftp ftps gluster host_cdrom host_device http https iscsi iser luks nbd nfs null-aio null-co parallels qcow qcow2 qed quorum raw rbd replication sheepdog ssh vdi vhdx vmdk vpc vvfat
```