### PR TITLE
Make the workspace path relative to the manifest file

### DIFF
--- a/bootstrapvz/base/bootstrapinfo.py
+++ b/bootstrapvz/base/bootstrapinfo.py
@@ -22,7 +22,9 @@ class BootstrapInformation(object):
 
         # Define the path to our workspace
         import os.path
-        self.workspace = os.path.join(manifest.bootstrapper['workspace'], self.run_id)
+        from bootstrapvz.common.tools import rel_path
+        self.workspace_root = rel_path(manifest.path, os.path.join(manifest.bootstrapper['workspace']))
+        self.workspace = os.path.join(self.workspace_root, self.run_id)
 
         # Load all the volume information
         from fs import load_volume

--- a/bootstrapvz/common/tasks/bootstrap.py
+++ b/bootstrapvz/common/tasks/bootstrap.py
@@ -38,7 +38,7 @@ def get_tarball_filename(info):
     # Filter info.root which points at /target/volume-id, we won't ever hit anything with that in there.
     hash_args = [arg for arg in arguments if arg != info.root]
     tarball_id = sha1(repr(frozenset(options + hash_args))).hexdigest()[0:8]
-    tarball_filename = 'debootstrap-' + tarball_id + '.tar'
+    tarball_filename = 'debootstrap-' + tarball_id + '.tgz'
     return os.path.join(os.path.abspath(info.workspace_root), tarball_filename)
 
 

--- a/bootstrapvz/common/tasks/bootstrap.py
+++ b/bootstrapvz/common/tasks/bootstrap.py
@@ -39,7 +39,7 @@ def get_tarball_filename(info):
     hash_args = [arg for arg in arguments if arg != info.root]
     tarball_id = sha1(repr(frozenset(options + hash_args))).hexdigest()[0:8]
     tarball_filename = 'debootstrap-' + tarball_id + '.tar'
-    return os.path.join(info.workspace_root, tarball_filename)
+    return os.path.join(os.path.abspath(info.workspace_root), tarball_filename)
 
 
 class MakeTarball(Task):

--- a/bootstrapvz/common/tasks/bootstrap.py
+++ b/bootstrapvz/common/tasks/bootstrap.py
@@ -39,7 +39,7 @@ def get_tarball_filename(info):
     hash_args = [arg for arg in arguments if arg != info.root]
     tarball_id = sha1(repr(frozenset(options + hash_args))).hexdigest()[0:8]
     tarball_filename = 'debootstrap-' + tarball_id + '.tar'
-    return os.path.join(info.manifest.bootstrapper['workspace'], tarball_filename)
+    return os.path.join(info.workspace_root, tarball_filename)
 
 
 class MakeTarball(Task):

--- a/bootstrapvz/common/tasks/image.py
+++ b/bootstrapvz/common/tasks/image.py
@@ -12,7 +12,7 @@ class MoveImage(Task):
         filename = image_name + '.' + info.volume.extension
 
         import os.path
-        destination = os.path.join(info.manifest.bootstrapper['workspace'], filename)
+        destination = os.path.join(info.workspace_root, filename)
         import shutil
         shutil.move(info.volume.image_path, destination)
         info.volume.image_path = destination

--- a/bootstrapvz/plugins/minimize_size/tasks/mounts.py
+++ b/bootstrapvz/plugins/minimize_size/tasks/mounts.py
@@ -22,7 +22,7 @@ class AddFolderMounts(Task):
 
             full_path = os.path.join(info.root, folder)
             os.chmod(temp_path, os.stat(full_path).st_mode)
-            info.volume.partition_map.root.add_mount(temp_path, full_path, ['--bind'])
+            info.volume.partition_map.root.add_mount(temp_path, folder, ['--bind'])
 
 
 class RemoveFolderMounts(Task):
@@ -35,9 +35,8 @@ class RemoveFolderMounts(Task):
         import shutil
         for folder in folders:
             temp_path = os.path.join(info._minimize_size['foldermounts'], folder.replace('/', '_'))
-            full_path = os.path.join(info.root, folder)
 
-            info.volume.partition_map.root.remove_mount(full_path)
+            info.volume.partition_map.root.remove_mount(folder)
             shutil.rmtree(temp_path)
 
         os.rmdir(info._minimize_size['foldermounts'])

--- a/bootstrapvz/plugins/prebootstrapped/tasks.py
+++ b/bootstrapvz/plugins/prebootstrapped/tasks.py
@@ -54,7 +54,7 @@ class CopyImage(Task):
     @classmethod
     def run(cls, info):
         loopback_backup_name = 'volume-{id}.{ext}.backup'.format(id=info.run_id, ext=info.volume.extension)
-        destination = os.path.join(info.manifest.bootstrapper['workspace'], loopback_backup_name)
+        destination = os.path.join(info.workspace_root, loopback_backup_name)
 
         with unmounted(info.volume):
             copyfile(info.volume.image_path, destination)
@@ -84,7 +84,7 @@ class CopyFolder(Task):
     @classmethod
     def run(cls, info):
         folder_backup_name = '{id}.{ext}.backup'.format(id=info.run_id, ext=info.volume.extension)
-        destination = os.path.join(info.manifest.bootstrapper['workspace'], folder_backup_name)
+        destination = os.path.join(info.workspace_root, folder_backup_name)
         log_check_call(['cp', '-a', info.volume.path, destination])
         msg = 'A copy of the bootstrapped volume was created. Path: ' + destination
         log.info(msg)

--- a/bootstrapvz/plugins/vagrant/tasks.py
+++ b/bootstrapvz/plugins/vagrant/tasks.py
@@ -16,7 +16,7 @@ class CheckBoxPath(Task):
     def run(cls, info):
         box_basename = info.manifest.name.format(**info.manifest_vars)
         box_name = box_basename + '.box'
-        box_path = os.path.join(info.manifest.bootstrapper['workspace'], box_name)
+        box_path = os.path.join(info.workspace_root, box_name)
         if os.path.exists(box_path):
             from bootstrapvz.common.exceptions import TaskError
             msg = 'The vagrant box `{name}\' already exists at `{path}\''.format(name=box_name, path=box_path)

--- a/bootstrapvz/providers/gce/tasks/image.py
+++ b/bootstrapvz/providers/gce/tasks/image.py
@@ -19,11 +19,11 @@ class CreateTarball(Task):
         image_name = image_name.replace(".", "-")
         info._gce['image_name'] = image_name
         tarball_name = image_name + '.tar.gz'
-        tarball_path = os.path.join(info.manifest.bootstrapper['workspace'], tarball_name)
+        tarball_path = os.path.join(info.workspace_root, tarball_name)
         info._gce['tarball_name'] = tarball_name
         info._gce['tarball_path'] = tarball_path
         # GCE requires that the file in the tar be named disk.raw, hence the transform
-        log_check_call(['tar', '--sparse', '-C', info.manifest.bootstrapper['workspace'],
+        log_check_call(['tar', '--sparse', '-C', info.workspace_root,
                         '-caf', tarball_path,
                         '--transform=s|.*|disk.raw|',
                         filename])

--- a/bootstrapvz/providers/oracle/tasks/image.py
+++ b/bootstrapvz/providers/oracle/tasks/image.py
@@ -16,9 +16,9 @@ class CreateImageTarball(Task):
         filename = image_name + '.' + info.volume.extension
 
         tarball_name = image_name + '.tar.gz'
-        tarball_path = os.path.join(info.manifest.bootstrapper['workspace'], tarball_name)
+        tarball_path = os.path.join(info.workspace_root, tarball_name)
         info._oracle['tarball_path'] = tarball_path
-        log_check_call(['tar', '--sparse', '-C', info.manifest.bootstrapper['workspace'],
+        log_check_call(['tar', '--sparse', '-C', info.workspace_root,
                         '-caf', tarball_path, filename])
 
 


### PR DESCRIPTION
Make the workspace path relative to the manifest file (resolves #424).

I had to modify ```minimize_size``` plugin. 

I left individual commits to show the process flow. 
