### PR TITLE
Tag ebs volumes when using ec2 provider

### DIFF
--- a/bootstrapvz/providers/ec2/README.rst
+++ b/bootstrapvz/providers/ec2/README.rst
@@ -169,6 +169,31 @@ Example:
       region: us-west-1
 
 
+Tags
+~~~~
+
+EBS volumes, snapshots and AMIs are tagged using AWS resource tags
+with the tag names and values defined in the manifest. Tags can be used to
+categorize AWS resources, e.g. by purpose or environment. They can also be
+used to limit access to resources using `IAM policies`__.
+
+__ https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_ec2_ebs-owner.html
+
+Example:
+
+.. code-block:: yaml
+
+    ---
+    tags:
+      Name: "Stretch 9.0 alpha"
+      Debian: "9.0~{%Y}{%m}{%d}{%H}{%M}"
+      Role: "test"
+
+Restrictions on tag names and values are defined in `EC2 docs`__.
+
+__ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
+
+
 Dependencies
 ------------
 

--- a/bootstrapvz/providers/ec2/ebsvolume.py
+++ b/bootstrapvz/providers/ec2/ebsvolume.py
@@ -4,16 +4,18 @@ from bootstrapvz.base.fs.exceptions import VolumeError
 
 class EBSVolume(Volume):
 
-    def create(self, conn, zone):
-        self.fsm.create(connection=conn, zone=zone)
+    def create(self, conn, zone, tags=[]):
+        self.fsm.create(connection=conn, zone=zone, tags=tags)
 
     def _before_create(self, e):
         self.conn = e.connection
         zone = e.zone
+        tags = e.tags
         size = self.size.bytes.get_qty_in('GiB')
         self.volume = self.conn.create_volume(Size=size,
                                               AvailabilityZone=zone,
-                                              VolumeType='gp2')
+                                              VolumeType='gp2',
+                                              TagSpecifications=[{'ResourceType': 'volume', 'Tags': tags}])
         self.vol_id = self.volume['VolumeId']
         waiter = self.conn.get_waiter('volume_available')
         waiter.wait(VolumeIds=[self.vol_id],

--- a/bootstrapvz/providers/ec2/tasks/ebs.py
+++ b/bootstrapvz/providers/ec2/tasks/ebs.py
@@ -8,7 +8,15 @@ class Create(Task):
 
     @classmethod
     def run(cls, info):
-        info.volume.create(info._ec2['connection'], info._ec2['host']['availabilityZone'])
+        tags = []
+
+        # Setting up tags on the EBS volume
+        if 'tags' in info.manifest.data:
+            raw_tags = info.manifest.data['tags']
+            formatted_tags = {k: v.format(**info.manifest_vars) for k, v in raw_tags.items()}
+            tags = [{'Key': k, 'Value': v} for k, v in formatted_tags.items()]
+
+        info.volume.create(info._ec2['connection'], info._ec2['host']['availabilityZone'], tags)
 
 
 class Attach(Task):


### PR DESCRIPTION
Add tags also to the EBS volume when it is created. The tags can be used to set more specific IAM policies that limit operations on the volumes.

The same tags are already set for ebs snapshots and AMIs.