### PR TITLE
select version for amzn-driver

### DIFF
--- a/bootstrapvz/providers/ec2/README.rst
+++ b/bootstrapvz/providers/ec2/README.rst
@@ -124,6 +124,28 @@ Example:
       virtualization: hvm
       enhanced_networking: simple
 
+Amazon Drivers
+~~~~~~~~~~~~~~
+
+Define the version for the Amazon Elastic Network
+Adapter (ENA) driver.
+Read more about this on the `Amazon Drivers git repo`__.
+
+__ https://github.com/amzn/amzn-drivers
+
+-  ``amzn-driver-version``: Default: master
+   Valid values: ``master``, ``#.#.#``
+   ``optional``
+
+Example:
+
+.. code-block:: yaml
+
+    ---
+    provider:
+      name: ec2
+      amzn-driver-version: 1.5.0
+
 Image
 ~~~~~
 

--- a/bootstrapvz/providers/ec2/manifest-schema.yml
+++ b/bootstrapvz/providers/ec2/manifest-schema.yml
@@ -24,6 +24,9 @@ properties:
         enum:
           - none
           - simple
+      amzn-driver-version:
+        type: string
+        pattern: "^([0-9]+\\.?){3}$"
     required: [description, virtualization]
   system:
     type: object


### PR DESCRIPTION
Add ability to declare version of the Amazon driver for EC2 instances. Currently, bootstrap-vz is pulling from master, but the version is incorrectly labeled at `1.0.0`.

I need to add docs, but I wanted feedback first.