### PR TITLE
Expose gpg flags for debootstrap

### DIFF
--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -36,6 +36,9 @@ properties:
       variant:
         type: string
         enum: [minbase]
+      keyring: {type: string}
+      no-check-gpg: {type: boolean}
+      force-check-gpg: {type: boolean}
     required: [workspace]
     additionalProperties: false
   system:

--- a/bootstrapvz/common/tasks/bootstrap.py
+++ b/bootstrapvz/common/tasks/bootstrap.py
@@ -23,6 +23,17 @@ def get_bootstrap_args(info):
     options = ['--arch=' + arch]
     if 'variant' in info.manifest.bootstrapper:
         options.append('--variant=' + info.manifest.bootstrapper['variant'])
+    if info.manifest.bootstrapper.get('keyring', ''):
+        options.append('--keyring=' + info.manifest.bootstrapper['keyring'])
+    if info.manifest.bootstrapper.get('no-check-gpg', False) is True:
+        options.append('--no-check-gpg')
+    if info.manifest.bootstrapper.get('force-check-gpg', False) is True:
+        from bootstrapvz.common.releases import stretch
+        if info.manifest.release >= stretch:
+            options.append('--force-check-gpg')
+        else:
+            from bootstrapvz.common.exceptions import ManifestError
+            raise ManifestError('force-check-gpg is only support in Stretch and newer releases')
     if len(info.include_packages) > 0:
         options.append('--include=' + ','.join(info.include_packages))
     if len(info.exclude_packages) > 0:

--- a/manifests/README.rst
+++ b/manifests/README.rst
@@ -74,8 +74,7 @@ Example:
 Bootstrapper
 ~~~~~~~~~~~~
 
-This section concerns the bootstrapper itself and its behavior. There
-are 4 possible settings:
+This section concerns the bootstrapper itself and its behavior.
 
 -  ``workspace``: Path to where the bootstrapper should place images
    and intermediate files. Any volumes will be mounted under that path.
@@ -108,6 +107,19 @@ are 4 possible settings:
    is ``minbase`` and should only be used in conjunction with the
    Docker provider. Not specifying this option will result in a normal
    Debian variant being bootstrapped.
+-  ``keyring``: path to keyring to check Release files against
+   ``optional``
+   Default: ``false``
+-  ``no-check-gpg``: avoid checking Release file signatures
+   ``optional``
+   Valid values: ``true, false``
+   Default: ``false``
+-  ``force-check-gpg``: force checking Release file signatures
+   (also disables automatic fallback to HTTPS in case
+   of a missing keyring), aborting otherwise
+   ``optional``
+   Valid values: ``true, false``
+   Default: ``false``
 
 
 Example:


### PR DESCRIPTION
Exposing GPG flags for debootstrap:
- `--keyring=K`
- `--no-check-gpg`
- `--force-check-gpg`