### PR TITLE
Add apt_repo plugin to add additional apt repos during image build

### DIFF
--- a/bootstrapvz/plugins/apt_repo/README.rst
+++ b/bootstrapvz/plugins/apt_repo/README.rst
@@ -1,0 +1,38 @@
+Add additional apt repos
+------------------------
+
+This plugin adds support for adding additional apt repositories. It imports
+the public repo key from the given URL and adds the sources list files. Multiple
+repositories are supported.
+
+The plugin supports also S3 backed repositories and it installs automatically
+apt-transport-s3 package.
+
+Example
+~~~~~~~
+
+.. code-block:: yaml
+
+    ---
+    plugins:
+      apt_repo:
+        dev:
+          url: s3://devbucket.s3.amazonaws.com/debian
+          release: stretch
+          components:
+            - main
+          key_url: https://host/devrepo.gpg
+        test:
+          url: s3://testbucket.s3.amazonaws.com/debian
+          release: stretch
+          components:
+            - main
+          key_url: https://host/testrepo.gpg
+
+Settings
+~~~~~~~~
+
+-  ``url``: URL of the apt repo root
+-  ``release``: Debian release
+-  ``components``: Array of components
+-  ``key_url``: URL of the public repo key

--- a/bootstrapvz/plugins/apt_repo/__init__.py
+++ b/bootstrapvz/plugins/apt_repo/__init__.py
@@ -1,0 +1,12 @@
+import tasks
+from bootstrapvz.common.tools import rel_path
+
+
+def validate_manifest(data, validator, error):
+    validator(data, rel_path(__file__, 'manifest-schema.yml'))
+
+
+def resolve_tasks(taskset, manifest):
+    taskset.add(tasks.S3BootstrapPackages)
+    taskset.add(tasks.AddRepoKey)
+    taskset.add(tasks.AddRepo)

--- a/bootstrapvz/plugins/apt_repo/manifest-schema.yml
+++ b/bootstrapvz/plugins/apt_repo/manifest-schema.yml
@@ -1,0 +1,30 @@
+---
+$schema: http://json-schema.org/draft-04/schema#
+title: Add custom repository
+type: object
+properties:
+  plugins:
+    type: object
+    properties:
+      apt_repo:
+        type: object
+        $ref: '#/definitions/apt_repos'
+
+definitions:
+  apt_repo:
+    type: object
+    properties:
+      url: {type: string}
+      release: {type: string}
+      components:
+        type: array
+        items:
+          type: string
+        minItems: 1
+        uniqueItems: true
+      key_url: {type: string}
+    additionalProperties: false
+
+  apt_repos:
+    patternProperties:
+      ^.*: {$ref: '#/definitions/apt_repo'}

--- a/bootstrapvz/plugins/apt_repo/tasks.py
+++ b/bootstrapvz/plugins/apt_repo/tasks.py
@@ -1,0 +1,49 @@
+from bootstrapvz.base import Task
+from bootstrapvz.common import phases
+from bootstrapvz.common.tasks import apt
+from bootstrapvz.common.tools import log_check_call
+import os
+
+
+class S3BootstrapPackages(Task):
+    description = 'Add apt repo support packages to bootstrap installation'
+    phase = phases.preparation
+
+    @classmethod
+    def run(cls, info):
+        info.include_packages.add('ca-certificates')
+        info.include_packages.add('apt-transport-s3')
+
+
+class AddRepoKey(Task):
+    description = 'Import additional apt repo keys'
+    phase = phases.package_installation
+    successors = [apt.WriteSources]
+
+    @classmethod
+    def run(cls, info):
+        for key in info.manifest.plugins['apt_repo'].iterkeys():
+            data = info.manifest.plugins['apt_repo'][key]
+            key_url = data['key_url']
+
+            key_file = os.path.join(info.root, 'tmp/repo.gpg')
+            log_check_call(['wget', key_url, '-O', key_file])
+            log_check_call(['chroot', info.root, 'apt-key', 'add', '/tmp/repo.gpg'])
+            os.remove(key_file)
+
+
+class AddRepo(Task):
+    description = 'Add additional apt repos'
+    phase = phases.preparation
+    predecessors = [apt.AddManifestSources]
+
+    @classmethod
+    def run(cls, info):
+        for key in info.manifest.plugins['apt_repo'].iterkeys():
+            data = info.manifest.plugins['apt_repo'][key]
+            url = data['url']
+            release = data['release']
+            components = data['components']
+
+            source = "deb %s %s %s" % (url, release, " ".join(components))
+            info.source_lists.add(key, source)


### PR DESCRIPTION
apt_repo plugin supports adding additional apt repositories that can be used to install packages during image build. To support S3 backed apt repos, apt-transport-s3 and ca-certificate packages are
installed during debootstrap.