### PR TITLE
Fix example docker manifest

### DIFF
--- a/manifests/examples/docker/jessie-minimized.yml
+++ b/manifests/examples/docker/jessie-minimized.yml
@@ -4,7 +4,7 @@ provider:
   name: docker
   labels:
     summary: Debian {system.release} {system.architecture}
-    description: >
+    description: >-
       Minimized version of Debian jessie
       without any manpages, additional documentation
       or other language files.


### PR DESCRIPTION
The new line at the end of the description value was breaking "Creating docker image"