### PR TITLE
Ability to create non-compressed QCOW

### DIFF
--- a/bootstrapvz/plugins/minimize_size/__init__.py
+++ b/bootstrapvz/plugins/minimize_size/__init__.py
@@ -16,6 +16,8 @@ def get_shrink_type(plugins):
         shrink_type = 'vmware-vdiskmanager'
     elif shrink_type is False:
         shrink_type = None
+    elif shrink_type == 'qemu-img-no-compression':
+        shrink_type = 'qemu-img'
     return shrink_type
 
 

--- a/bootstrapvz/plugins/minimize_size/manifest-schema.yml
+++ b/bootstrapvz/plugins/minimize_size/manifest-schema.yml
@@ -8,7 +8,7 @@ properties:
           shrink:
             anyOf:
               - type: boolean
-              - enum: [vmware-vdiskmanager, qemu-img]
+              - enum: [vmware-vdiskmanager, qemu-img, qemu-img-no-compression]
           zerofree:
             type: boolean
           apt:

--- a/bootstrapvz/plugins/minimize_size/tasks/shrink.py
+++ b/bootstrapvz/plugins/minimize_size/tasks/shrink.py
@@ -71,8 +71,9 @@ class ShrinkVolumeWithQemuImg(Task):
     def run(cls, info):
         tmp_name = os.path.join(info.workspace, 'shrunk.' + info.volume.extension)
         shrink_cmd = ['qemu-img', 'convert', '-O', info.volume.extension, info.volume.image_path, tmp_name]
-        # Compress QCOW2 image when shrinking
-        if info.volume.extension == 'qcow2':
+        # Compress QCOW2 image when shrinking except when explicitly set not to
+        if (info.volume.extension == 'qcow2' and
+                info.manifest.plugins['minimize_size']['shrink'] != 'qemu-img-no-compression'):
             # '-c' indicates that target image must be compressed (qcow format only)
             shrink_cmd.insert(4, '-c')
         log_check_call(shrink_cmd)

--- a/manifests/examples/kvm/stretch-cloudimg.yml
+++ b/manifests/examples/kvm/stretch-cloudimg.yml
@@ -1,0 +1,48 @@
+---
+name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
+provider:
+  name: kvm
+  virtio:
+    - virtio
+    - virtio_pci
+    - virtio_balloon
+    - virtio_blk
+    - virtio_net
+    - virtio_ring
+  console: virtual
+bootstrapper:
+  workspace: /target
+system:
+  release: stretch
+  architecture: amd64
+  bootloader: grub
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+packages:
+  components:
+    - main
+    - contrib
+    - non-free
+  install_standard: true
+  install:
+    - task-ssh-server
+    - cloud-init
+    - cloud-utils
+volume:
+  backing: qcow2
+  partitions:
+    type: msdos
+    root:
+      filesystem: ext4
+      size: 2GiB
+      mountopts:
+        - defaults
+        - noatime
+        - errors=remount-ro
+plugins:
+  minimize_size:
+    zerofree: true
+    shrink: qemu-img
+    apt:
+      autoclean: true


### PR DESCRIPTION
Add new shrink type to the minimize_size plugin, `qemu-img-no-compression`, to add the ability to create non-compressed QCOWs