### PR TITLE
Correct virtio param in example manifests

### DIFF
--- a/manifests/examples/kvm/jessie-arm64-virtio.yml
+++ b/manifests/examples/kvm/jessie-arm64-virtio.yml
@@ -2,7 +2,7 @@
 name: debian-{system.release}-{system.architecture}-{%y}{%m}{%d}
 provider:
   name: kvm
-  virtio_modules:
+  virtio:
     - virtio_pci
     - virtio_blk
 bootstrapper:

--- a/manifests/examples/kvm/jessie-puppet.yaml
+++ b/manifests/examples/kvm/jessie-puppet.yaml
@@ -2,7 +2,7 @@
 name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
 provider:
   name: kvm
-  virtio_modules:
+  virtio:
     - virtio_pci
     - virtio_blk
 bootstrapper:

--- a/manifests/examples/kvm/jessie-virtio.yml
+++ b/manifests/examples/kvm/jessie-virtio.yml
@@ -2,7 +2,7 @@
 name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
 provider:
   name: kvm
-  virtio_modules:
+  virtio:
     - virtio_pci
     - virtio_blk
 bootstrapper:

--- a/manifests/examples/kvm/stretch-console.yml
+++ b/manifests/examples/kvm/stretch-console.yml
@@ -2,10 +2,10 @@
 name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
 provider:
   name: kvm
-  virtio_modules:
+  virtio:
     - virtio_blk
     - virtio_net
-    - virtio_rng
+    - virtio_ring
   console: virtual
 bootstrapper:
   workspace: /target

--- a/manifests/examples/kvm/stretch-puppet.yaml
+++ b/manifests/examples/kvm/stretch-puppet.yaml
@@ -2,7 +2,7 @@
 name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
 provider:
   name: kvm
-  virtio_modules:
+  virtio:
     - virtio_pci
     - virtio_blk
 bootstrapper:

--- a/manifests/examples/kvm/stretch-virtio-partitions.yml
+++ b/manifests/examples/kvm/stretch-virtio-partitions.yml
@@ -2,7 +2,7 @@
 name: debian-{system.release}-{system.architecture}-{%Y}{%m}{%d}
 provider:
   name: kvm
-  virtio_modules:
+  virtio:
     - virtio_pci
     - virtio_blk
 bootstrapper:

--- a/manifests/examples/kvm/wheezy-virtio.yml
+++ b/manifests/examples/kvm/wheezy-virtio.yml
@@ -2,7 +2,7 @@
 name: debian-{system.release}-{system.architecture}-{%y}{%m}{%d}
 provider:
   name: kvm
-  virtio_modules:
+  virtio:
     - virtio_pci
     - virtio_blk
 bootstrapper:


### PR DESCRIPTION
Fix example manifest for the virtio modules, virtio_modules -> virtio