### PR TITLE
Allow relative paths to workspace

### DIFF
--- a/bootstrapvz/base/manifest.py
+++ b/bootstrapvz/base/manifest.py
@@ -5,6 +5,7 @@ invocations should have etc..
 from bootstrapvz.common.exceptions import ManifestError
 from bootstrapvz.common.tools import load_data, rel_path
 import logging
+import os.path
 log = logging.getLogger(__name__)
 
 
@@ -113,6 +114,8 @@ class Manifest(object):
         # The packages and plugins sections are not required
         self.packages     = self.data['packages'] if 'packages' in self.data else {}
         self.plugins      = self.data['plugins'] if 'plugins' in self.data else {}
+
+        self.bootstrapper['workspace'] = os.path.abspath(rel_path(self.path, self.bootstrapper['workspace']))
 
     def schema_validator(self, data, schema_path):
         """This convenience function is passed around to all the validation functions


### PR DESCRIPTION
I like having my paths relative.

I've noticed that wherever a plugin wanted to allow relative paths, yet some tool used by that plugin required an absolute path, the path was converted from relative to absolute somewhere close to the place where the absolute path was required.

At first, I tried to do the same. I started patching all places that used the workspace path, and that would fail at runtime with just a relative path. But it turns out there's quite a lot of places that fail; my somewhat minimalistic test case already required 7 changes.

Then I realized it would be better to have the path relative to the manifest file, not just the current directory—just like the ["vbox: Make guest additions path relative to manifest"](https://github.com/andsens/bootstrap-vz/commit/bf7525426b40d37403d84076132219a0bb839a0a) patch. So, I'd essentially need to patch all the places.

So, I decided to just modify the manifest itself during the "parsing" step. I've noticed that the current code carefully avoids modifying the manifest data structure, probably for a good reason… but this just feels the right approach to me here. Though, maybe there is a better way?