### PR TITLE
Create device dirs if they do not exist

### DIFF
--- a/bootstrapvz/base/fs/partitions/base.py
+++ b/bootstrapvz/base/fs/partitions/base.py
@@ -86,6 +86,7 @@ class BasePartition(AbstractPartition):
         # $GRUB_DEVICE_UUID when creating /boot/grub/grub.cfg
         self.disk_by_uuid_path = os.path.join('/dev/disk/by-uuid', self.get_uuid())
         if not os.path.exists(self.disk_by_uuid_path):
+            os.makedirs(os.path.dirname(self.disk_by_uuid_path))
             os.symlink(self.device_path, self.disk_by_uuid_path)
 
     def unlink_uuid(self):


### PR DESCRIPTION
Some build environments (e.g. Google Cloud Container Builder docker
images) don't have enough of a /dev filesystem to have
/dev/disk/by-uuid/ by default. Make them if they don't exist.