### PR TITLE
Add support for encrypted AMIs

### DIFF
--- a/bootstrapvz/providers/ec2/README.rst
+++ b/bootstrapvz/providers/ec2/README.rst
@@ -146,6 +146,30 @@ Example:
       name: ec2
       amzn-driver-version: 1.5.0
 
+Encrypted volumes
+~~~~~~~~~~~~~~~~~
+
+Encrypted AMIs that can be used to launch instances with encrypted boot volume
+are supported. Defining encryption key is optional and EC2 uses default
+encryption key if one is not set. Encryption works only with EBS volumes.
+
+- ``encrypted:``: Default: False
+  Valid values: ``True``, ``False``
+  ``optional``
+- ``kms_key_id:``: Default: EC2 default EBS encryption key
+  Valid values: arn of the KMS key
+  ``optional``
+
+Example:
+
+.. code-block:: yaml
+
+    ---
+    provider:
+      name: ec2
+      encrypted: True
+      kms_key_id: arn:aws:kms:us-east-1:1234567890:key/00000000-0000-0000-0000-000000000000
+
 Image
 ~~~~~
 

--- a/bootstrapvz/providers/ec2/__init__.py
+++ b/bootstrapvz/providers/ec2/__init__.py
@@ -26,7 +26,7 @@ def validate_manifest(data, validator, error):
     bootloader = data['system']['bootloader']
     virtualization = data['provider']['virtualization']
     encrypted = data['provider'].get('encrypted', False)
-    kms_key_id = data['provider'].get('kms_key_id')
+    kms_key_id = data['provider'].get('kms_key_id', None)
     backing = data['volume']['backing']
     partition_type = data['volume']['partitions']['type']
     enhanced_networking = data['provider']['enhanced_networking'] if 'enhanced_networking' in data['provider'] else None

--- a/bootstrapvz/providers/ec2/__init__.py
+++ b/bootstrapvz/providers/ec2/__init__.py
@@ -25,6 +25,8 @@ def validate_manifest(data, validator, error):
 
     bootloader = data['system']['bootloader']
     virtualization = data['provider']['virtualization']
+    encrypted = data['provider'].get('encrypted', False)
+    kms_key_id = data['provider'].get('kms_key_id')
     backing = data['volume']['backing']
     partition_type = data['volume']['partitions']['type']
     enhanced_networking = data['provider']['enhanced_networking'] if 'enhanced_networking' in data['provider'] else None
@@ -37,6 +39,12 @@ def validate_manifest(data, validator, error):
 
     if backing == 's3' and partition_type != 'none':
             error('S3 backed AMIs currently only work with unpartitioned volumes', ['system', 'bootloader'])
+
+    if backing != 'ebs' and encrypted:
+            error('Encryption is supported only on EBS volumes')
+
+    if encrypted is False and kms_key_id is not None:
+            error('KMS Key Id can be set only when encryption is enabled')
 
     if enhanced_networking == 'simple' and virtualization != 'hvm':
             error('Enhanced networking only works with HVM virtualization', ['provider', 'virtualization'])

--- a/bootstrapvz/providers/ec2/manifest-schema.yml
+++ b/bootstrapvz/providers/ec2/manifest-schema.yml
@@ -27,6 +27,8 @@ properties:
       amzn-driver-version:
         type: string
         pattern: "^([0-9]+\\.?){3}$"
+      encrypted: { type: boolean }
+      kms_key_id: { type: string }
     required: [description, virtualization]
   system:
     type: object

--- a/bootstrapvz/providers/ec2/tasks/ebs.py
+++ b/bootstrapvz/providers/ec2/tasks/ebs.py
@@ -19,7 +19,7 @@ class Create(Task):
         # EBS volumes support encryption. KMS key id is optional and default key
         # is used when it is not defined.
         encrypted = info.manifest.data['provider'].get('encrypted', False)
-        kms_key_id = info.manifest.data['provider'].get('kms_key_id')
+        kms_key_id = info.manifest.data['provider'].get('kms_key_id', None)
 
         info.volume.create(info._ec2['connection'], info._ec2['host']['availabilityZone'], tags=tags, encrypted=encrypted, kms_key_id=kms_key_id)
 

--- a/bootstrapvz/providers/ec2/tasks/ebs.py
+++ b/bootstrapvz/providers/ec2/tasks/ebs.py
@@ -16,7 +16,12 @@ class Create(Task):
             formatted_tags = {k: v.format(**info.manifest_vars) for k, v in raw_tags.items()}
             tags = [{'Key': k, 'Value': v} for k, v in formatted_tags.items()]
 
-        info.volume.create(info._ec2['connection'], info._ec2['host']['availabilityZone'], tags)
+        # EBS volumes support encryption. KMS key id is optional and default key
+        # is used when it is not defined.
+        encrypted = info.manifest.data['provider'].get('encrypted', False)
+        kms_key_id = info.manifest.data['provider'].get('kms_key_id')
+
+        info.volume.create(info._ec2['connection'], info._ec2['host']['availabilityZone'], tags=tags, encrypted=encrypted, kms_key_id=kms_key_id)
 
 
 class Attach(Task):


### PR DESCRIPTION
This adds support for using encrypted EBS volume with EC2 provider. The resulting snapshot and AMI are encrypted and they can be used to launch EC2 instances with encrypted root volume. Custom KMS key can be used by specifying kms_key_id or otherwise the default kms key is used.

More information about AMI encryption:

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIEncryption.html

Closes #405 

This pull request conflicts with https://github.com/andsens/bootstrap-vz/pull/446 that I can update if this is merged first.