### PR TITLE
Add cloud-init for gce images

### DIFF
--- a/bootstrapvz/plugins/cloud_init/manifest-schema.yml
+++ b/bootstrapvz/plugins/cloud_init/manifest-schema.yml
@@ -9,6 +9,7 @@ properties:
       release:
         type: string
         enum:
+        - buster
         - wheezy
         - oldstable
         - jessie

--- a/manifests/official/gce/buster.yml
+++ b/manifests/official/gce/buster.yml
@@ -51,3 +51,6 @@ plugins:
     download_interval: 1
     update_interval: 1
     upgrade_interval: 1
+  cloud_init:
+    metadata_sources: GCE
+    username: debian

--- a/manifests/official/gce/jessie.yml
+++ b/manifests/official/gce/jessie.yml
@@ -55,3 +55,6 @@ plugins:
     download_interval: 1
     update_interval: 1
     upgrade_interval: 1
+  cloud_init:
+    metadata_sources: GCE
+    username: debian

--- a/manifests/official/gce/stretch.yml
+++ b/manifests/official/gce/stretch.yml
@@ -51,3 +51,6 @@ plugins:
     download_interval: 1
     update_interval: 1
     upgrade_interval: 1
+  cloud_init:
+    metadata_sources: GCE
+    username: debian


### PR DESCRIPTION
There doesn't appear to be an easily locatable documented reason that
the GCE official Debian images don't install and configure cloud-init.
This causes the GCE documentation on the `user-data` metadata to not
be accurate.

This change makes the GCE images function with `#cloud-config` format
`user-data`.

The negative impact of this is that cloud-init will make a few changes
on first boot, even if the user did not specify `user-data` metadata.
This appears to be standard and ok in the ec2 and oracle manifests,
though. The official GCE Ubuntu images also appear to create an ubuntu
user on first boot, so it seems like there's parity.

The cloud_init plugin options are burgled from the most common form in
the ec2 and oracle manifests, which is effectively no config other than
setting a username.

I've set the username to what the default is in the Debian cloud-init
package to avoid making arbitrary decisions that don't matter. If I
could disable the default user section as it is in the COS cloud.cfg,
I'd prefer that, but as is the cloud_init plugin is not particularly
flexible, and rewriting it to be seems like overkill.