### PR TITLE
Fix issues in building Debian testing images

### DIFF
--- a/bootstrapvz/providers/ec2/tasks/network.py
+++ b/bootstrapvz/providers/ec2/tasks/network.py
@@ -1,7 +1,8 @@
+import os.path
+
 from bootstrapvz.base import Task
 from bootstrapvz.common import phases
 from bootstrapvz.common.tasks import kernel
-import os.path
 
 
 class InstallDHCPCD(Task):
@@ -89,8 +90,8 @@ class InstallEnhancedNetworking(Task):
     def run(cls, info):
         from bootstrapvz.common.releases import stretch
         if info.manifest.release >= stretch:
-            version = '4.2.1'
-            drivers_url = 'https://downloadmirror.intel.com/27160/eng/ixgbevf-4.2.1.tar.gz'
+            version = '4.3.4'
+            drivers_url = 'https://downloadmirror.intel.com/18700/eng/ixgbevf-4.3.4.tar.gz'
         else:
             version = '3.2.2'
             drivers_url = 'https://downloadmirror.intel.com/26561/eng/ixgbevf-3.2.2.tar.gz'

--- a/bootstrapvz/providers/ec2/tasks/packages-kernels.yml
+++ b/bootstrapvz/providers/ec2/tasks/packages-kernels.yml
@@ -9,6 +9,9 @@ jessie:
 stretch:
   amd64: linux-image-amd64
   i386: linux-image-686-pae
+buster:
+  amd64: linux-image-amd64
+  i386: linux-image-686-pae
 sid:
   amd64: linux-image-amd64
   i386: linux-image-686-pae


### PR DESCRIPTION
- Upgrade Intel networking driver version to support Linux kernel versions 2.6.18 up through 4.15
Building Debian testing images fails with existing version of this driver.
- Added an option for buster in ec2 kernel-packages list to be able to build testing images.

Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>