### PR TITLE
set permissions for apt gpg pub keys

### DIFF
--- a/bootstrapvz/common/tasks/apt.py
+++ b/bootstrapvz/common/tasks/apt.py
@@ -115,6 +115,7 @@ class InstallTrustedKeys(Task):
             key_name = os.path.basename(key_path)
             destination = os.path.join(info.root, 'etc/apt/trusted.gpg.d', key_name)
             copy(key_path, destination)
+            os.chmod(destination, 0o644)
 
 
 class WriteConfiguration(Task):


### PR DESCRIPTION
Set permission on trusted.gpg file to 644 to address:
`The key(s) in the keyring /etc/apt/trusted.gpg.d/* are ignored as the file is not readable by user '_apt' executing apt-key.`