### PR TITLE
Add libvirt support for vagrant plugin

### DIFF
--- a/bootstrapvz/plugins/vagrant/README.rst
+++ b/bootstrapvz/plugins/vagrant/README.rst
@@ -9,4 +9,10 @@ of the virtual machine.
 
 This plugin creates a vagrant box that is ready to be shared or
 deployed. At the moment it is only compatible with the VirtualBox
-provider and doesn't requires any additional settings.
+and Libvirt providers.
+
+Settings
+~~~~~~~~
+
+-  ``provider``: Specifies the provider of a resulting vagrant box.
+   ``optional`` Valid values: ``virtualbox, libvirt`` Default: ``libvirt``

--- a/bootstrapvz/plugins/vagrant/__init__.py
+++ b/bootstrapvz/plugins/vagrant/__init__.py
@@ -6,6 +6,11 @@ from bootstrapvz.common.tools import rel_path
 
 def validate_manifest(data, validator, error):
     validator(data, rel_path(__file__, 'manifest-schema.yml'))
+    vagrant_provider = data['plugins']['vagrant'].get('provider', 'virtualbox')
+    if vagrant_provider == 'virtualbox' and data['volume']['backing'] != 'vmdk':
+        error('Virtualbox vagrant boxes support vmdk images only', ['plugins', 'vagrant', 'provider'])
+    if vagrant_provider == 'libvirt' and data['volume']['backing'] != 'qcow2':
+        error('Libvirt vagrant boxes support qcow2 images only', ['plugins', 'vagrant', 'provider'])
 
 
 def resolve_tasks(taskset, manifest):

--- a/bootstrapvz/plugins/vagrant/manifest-schema.yml
+++ b/bootstrapvz/plugins/vagrant/manifest-schema.yml
@@ -8,7 +8,7 @@ properties:
     properties:
       name:
         type: string
-        enum: [virtualbox]
+        enum: [virtualbox, kvm]
   system:
     required: [hostname]
   volume:
@@ -16,11 +16,15 @@ properties:
     properties:
       backing:
         type: string
-        enum: [vmdk]
+        enum: [vmdk, qcow2]
     required: [backing]
   plugins:
     type: object
     properties:
       vagrant:
         type: object
+        properties:
+          provider:
+            type: string
+            enum: [virtualbox, libvirt]
         additionalProperties: false


### PR DESCRIPTION
``provider`` options for vagrant plugin. When set to ``libvirt`` box will be packed with ``metadata.json`` that works with vagrant-libvirt plugin.