### PR TITLE
Install pip via the boostrap get-pip.py file

### DIFF
--- a/bootstrapvz/plugins/pip_install/tasks.py
+++ b/bootstrapvz/plugins/pip_install/tasks.py
@@ -8,7 +8,7 @@ class AddPipPackage(Task):
 
     @classmethod
     def run(cls, info):
-        for package_name in ('python-pip', 'build-essential', 'python-dev'):
+        for package_name in ('build-essential', 'python-dev', 'wget'):
             info.packages.add(package_name)
 
 
@@ -22,4 +22,6 @@ class PipInstallCommand(Task):
         packages = info.manifest.plugins['pip_install']['packages']
         pip_install_command = ['chroot', info.root, 'pip', 'install']
         pip_install_command.extend(packages)
+        log_check_call(['chroot', info.root, 'wget', 'https://bootstrap.pypa.io/get-pip.py'])
+        log_check_call(['chroot', info.root, 'python', 'get-pip.py'])
         log_check_call(pip_install_command)


### PR DESCRIPTION
Installing pip via apt has, historically, been flaky at _best_. A few months ago, I was unable to build my debian image that needed to install python packages, because the python-pip install was failing.
Additionally,  python-pip in apt is frequently very out of date, and this method guarantees the latest version when new images are built.

This PR removes `python-pip`, adds `wget`, and runs the bootstrap get-pip.py installer to install pip.

The url for installing pip was pulled from the [official pip installation guide](https://pip.pypa.io/en/stable/installing/).