### PR TITLE
Fix cloud-init setup broken by pylint changes

### DIFF
--- a/bootstrapvz/common/tools.py
+++ b/bootstrapvz/common/tools.py
@@ -83,7 +83,7 @@ def inline_replace(file_path, pattern, subst):
     for line in fileinput.input(files=file_path, inplace=True):
         (replacement, count) = re.subn(pattern, subst, line)
         replacement_count += count
-        print(replacement, end=' ')
+        print(replacement, end='')
     return replacement_count
 
 

--- a/bootstrapvz/plugins/cloud_init/tasks.py
+++ b/bootstrapvz/plugins/cloud_init/tasks.py
@@ -100,7 +100,7 @@ class DisableModules(Task):
         import fileinput
         for line in fileinput.input(files=cloud_cfg, inplace=True):
             if not regex.match(line):
-                print(line, end=' ')
+                print(line, end='')
 
 
 class EnableModules(Task):
@@ -124,7 +124,7 @@ class EnableModules(Task):
                         count = count + 1
                     if int(entry['position']) == int(count):
                         print(" - %s" % entry['module'])
-                    print(line, end=' ')
+                    print(line, end='')
 
 
 class SetCloudInitMountOptions(Task):

--- a/bootstrapvz/plugins/ntp/tasks.py
+++ b/bootstrapvz/plugins/ntp/tasks.py
@@ -31,4 +31,4 @@ class SetNtpServers(Task):
                 while servers:
                     print('server {server_address} iburst'.format(server_address=servers.pop(0)))
             else:
-                print(line, end=' ')
+                print(line, end='')


### PR DESCRIPTION
Commit 701678c9 changes print statements to print functions with end=' '. As the printed strings contain newlines, this causes a space to be written as the first character of the following line causing them to be indented.

An example config that is broken. Here disabling modules indents all the other lines of cloud.cfg except the first one causing the username name setting to fail as it expects indenting to be certain number of spaces.

```
plugins:
  cloud_init:
    metadata_sources: Ec2
    username: admin
    disable_modules:
      - locale
      - mounts
```

This commit removes the spaces by specifying end=''.