### PR TITLE
NVMe support for ec2 provider

### DIFF
--- a/bootstrapvz/providers/ec2/ebsvolume.py
+++ b/bootstrapvz/providers/ec2/ebsvolume.py
@@ -34,7 +34,7 @@ class EBSVolume(Volume):
         self.fsm.attach(instance_id=instance_id)
 
     def _before_attach(self, e):
-        import os
+        import os.path
         import string
         import urllib2
 


### PR DESCRIPTION
Fixes: #452

Adds support for building on EC2 hosts that have NVMe EBS devices.

Introduces the DescribeInstances permission requirement for the calling
role.

Changes the device naming logic on the host during build time.
- The new target volume will be mounted with the highest available
  DeviceName in the BlockDeviceMapping object, taking care to avoid
  assignments that also are allocated at launch to ephemeral devices
  (C5d, I3, F1, and M5d currently).
- The system device name will be identifed by the difference between the
  existing block devices prior to and after the AttachVolume call has
  finished. This does not address the race condition identified in #459.