### PR TITLE
Adjust chroot environment vars and add --allow-unathuenticated for apt-get

### DIFF
--- a/bootstrapvz/common/tasks/apt.py
+++ b/bootstrapvz/common/tasks/apt.py
@@ -213,11 +213,11 @@ class AptUpgrade(Task):
                             'apt-get', 'install',
                                        '--fix-broken',
                                        '--no-install-recommends',
-                                       '--assume-yes'])
+                                       '--assume-yes', '--allow-unauthenticated'])
             log_check_call(['chroot', info.root,
                             'apt-get', 'upgrade',
                                        '--no-install-recommends',
-                                       '--assume-yes'])
+                                       '--assume-yes', '--allow-unauthenticated'])
         except CalledProcessError as e:
             if e.returncode == 100:
                 msg = ('apt exited with status code 100. '

--- a/bootstrapvz/common/tasks/locale.py
+++ b/bootstrapvz/common/tasks/locale.py
@@ -33,8 +33,7 @@ class GenerateLocale(Task):
         sed_i(locale_gen, search, locale_str)
 
         log_check_call(['chroot', info.root, 'locale-gen'])
-        log_check_call(['chroot', info.root,
-                        'update-locale', 'LANG=' + lang])
+        log_check_call(['chroot', info.root, 'update-locale', 'LANG=' + lang])
 
 
 class SetTimezone(Task):

--- a/bootstrapvz/common/tasks/packages.py
+++ b/bootstrapvz/common/tasks/packages.py
@@ -48,7 +48,7 @@ class InstallPackages(Task):
             log_check_call(['chroot', info.root,
                             'apt-get', 'install',
                                        '--no-install-recommends',
-                                       '--assume-yes'] +
+                                       '--assume-yes', '--allow-unauthenticated'] +
                            map(str, remote_packages),
                            env=env)
         except CalledProcessError as e:

--- a/bootstrapvz/common/tools.py
+++ b/bootstrapvz/common/tools.py
@@ -26,9 +26,9 @@ def log_call(command, stdin=None, env=None, shell=False, cwd=None):
     command_log = realpath(command[0]).replace('/', '.')
     log = logging.getLogger(__name__ + command_log)
     if isinstance(command, list):
-        log.debug('Executing: {command}'.format(command=' '.join(command)))
+        log.debug('Executing: {command} env={env}'.format(command=' '.join(command), env=env))
     else:
-        log.debug('Executing: {command}'.format(command=command))
+        log.debug('Executing: {command} env={env}'.format(command=command, env=env))
 
     process = subprocess.Popen(args=command, env=env, shell=shell, cwd=cwd,
                                stdin=subprocess.PIPE,

--- a/bootstrapvz/common/tools.py
+++ b/bootstrapvz/common/tools.py
@@ -3,8 +3,6 @@ import os
 
 
 def log_check_call(command, stdin=None, env=None, shell=False, cwd=None):
-    env = env or {}
-    env['PATH'] = env.get('PATH', '') + ':/usr/sbin:/sbin:/bin:/usr/bin'
     status, stdout, stderr = log_call(command, stdin, env, shell, cwd)
     from subprocess import CalledProcessError
     if status != 0:
@@ -23,6 +21,9 @@ def log_call(command, stdin=None, env=None, shell=False, cwd=None):
     from multiprocessing.dummy import Pool as ThreadPool
     from os.path import realpath
 
+    env = env or {}
+    env['PATH'] = env.get('PATH', '') + ':/usr/sbin:/sbin:/bin:/usr/bin'
+    env['DEBIAN_FRONTEND'] = env.get('DEBIAN_FRONTEND', 'noninteractive')
     command_log = realpath(command[0]).replace('/', '.')
     log = logging.getLogger(__name__ + command_log)
     if isinstance(command, list):

--- a/bootstrapvz/common/tools.py
+++ b/bootstrapvz/common/tools.py
@@ -3,6 +3,8 @@ import os
 
 
 def log_check_call(command, stdin=None, env=None, shell=False, cwd=None):
+    env = env or {}
+    env['PATH'] = env.get('PATH', '') + ':/usr/sbin:/sbin:/bin:/usr/bin'
     status, stdout, stderr = log_call(command, stdin, env, shell, cwd)
     from subprocess import CalledProcessError
     if status != 0:


### PR DESCRIPTION
I have used the software in ArchLinux and I have experienced some problems during the building of a new image.

They were mainly given by the two arguments in topic.

I added also logging of the env vars in `log_call`.

I have succeeded in creating my custom vagrant box.