### PR TITLE
Fix a couple of (presumed) issues with regex escaping.

### DIFF
--- a/bootstrapvz/plugins/puppet/tasks.py
+++ b/bootstrapvz/plugins/puppet/tasks.py
@@ -147,7 +147,7 @@ class ApplyPuppetManifest(Task):
         log_check_call(['chroot', info.root, 'puppet', 'apply', '--verbose', '--debug', manifest_path])
         os.remove(manifest_dst)
         hosts_path = os.path.join(info.root, 'etc/hosts')
-        sed_i(hosts_path, '127.0.0.1\\s*{hostname}\n?'.format(hostname=hostname), '')
+        sed_i(hosts_path, r'127.0.0.1\s*{hostname}\n?'.format(hostname=hostname), '')
 
 
 class EnableAgent(Task):

--- a/bootstrapvz/providers/ec2/tasks/boot.py
+++ b/bootstrapvz/providers/ec2/tasks/boot.py
@@ -53,7 +53,7 @@ class CreatePVGrubCustomRule(Task):
             grub_device = 'GRUB_DEVICE=/dev/xvda' + str(root_idx)
             sed_i(script_dst, '^GRUB_DEVICE=/dev/xvda$', grub_device)
             grub_root = '\troot (hd0,{idx})'.format(idx=root_idx - 1)
-            sed_i(script_dst, '^\troot \\(hd0\\)$', grub_root)
+            sed_i(script_dst, r'^\troot \(hd0\)$', grub_root)
 
         if info.manifest.volume['backing'] == 's3':
             from bootstrapvz.common.tools import sed_i


### PR DESCRIPTION
In each of these cases we have an un-escaped \n or \t that
gets passed to a regex.  That means that the regexes actually
contain tabs or newlines, respectively.  After this change
an actual '\t' and '\n' are passed in instead.

I have not tested this!  I am writing this patch based on
the assumption that /surely/ the original authors meant
to pass in \t and \n to the regex and not actual tab
or newline characters.